### PR TITLE
fix: middleware causes crash

### DIFF
--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -50,11 +50,13 @@ func FromContext(ctx context.Context) *slog.Logger {
 	return NewLogger()
 }
 
-// Take whatever context we already have and write it into the request context
+// Take the logger from the context and add it to the request context
 func Middleware(ctx context.Context) func(http.Handler) http.Handler {
+	log := FromContext(ctx)
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			next.ServeHTTP(w, r.WithContext(ctx))
+			reqCtx := IntoContext(r.Context(), log)
+			next.ServeHTTP(w, r.WithContext(reqCtx))
 		})
 	}
 


### PR DESCRIPTION
## Motivation

Using the logger middleware causes the application to crash.

## Fix

Take the logger out of the context and write it into the request context. The issue was, that we were rewriting the request context with our context, which essentially removes any context added by chi. This causes an issue internally when chi tries to retrieve the request context to read some of its own injected metadata. The key for this does not exist due to us overwriting it, so the following type assertion fails, since chi is essentially doing this `reqCtx := nil.(RequestContext)` without an ok check, causing a panic.

