### PR TITLE
fix: latency req timeout calc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ gen
 
 # test configs for debug launch configuration
 .vscode/config
+
+# Temporary directory
+.tmp/*

--- a/pkg/checks/latency_test.go
+++ b/pkg/checks/latency_test.go
@@ -40,7 +40,7 @@ func TestLatency_Run(t *testing.T) {
 		want    Result
 	}{
 		{
-			name: "runs successfully a latency check",
+			name: "success with one target",
 			registeredEndpoints: []struct {
 				name    string
 				status  int
@@ -48,7 +48,7 @@ func TestLatency_Run(t *testing.T) {
 			}{
 				{
 					name:    successURL,
-					status:  200,
+					status:  http.StatusOK,
 					success: true,
 				},
 			},
@@ -57,6 +57,41 @@ func TestLatency_Run(t *testing.T) {
 			want: Result{
 				Data: map[string]LatencyResult{
 					successURL: {Code: http.StatusOK, Error: nil, Total: 0},
+				},
+				Timestamp: time.Time{},
+				Err:       "",
+			},
+		},
+		{
+			name: "success with multiple targets",
+			registeredEndpoints: []struct {
+				name    string
+				status  int
+				success bool
+			}{
+				{
+					name:    successURL,
+					status:  http.StatusOK,
+					success: true,
+				},
+				{
+					name:    failURL,
+					status:  http.StatusInternalServerError,
+					success: true,
+				},
+				{
+					name:    timeoutURL,
+					status:  0,
+					success: false,
+				},
+			},
+			targets: []string{successURL, failURL, timeoutURL},
+			ctx:     context.Background(),
+			want: Result{
+				Data: map[string]LatencyResult{
+					successURL: {Code: http.StatusOK, Error: nil, Total: 0},
+					failURL:    {Code: http.StatusInternalServerError, Error: nil, Total: 0},
+					timeoutURL: {Code: 0, Error: stringPointer(fmt.Sprintf("Get %q: context deadline exceeded", timeoutURL)), Total: 0},
 				},
 				Timestamp: time.Time{},
 				Err:       "",

--- a/pkg/sparrow/api.go
+++ b/pkg/sparrow/api.go
@@ -73,7 +73,7 @@ func (s *Sparrow) api(ctx context.Context) error {
 	// run http server in goroutine
 	go func(cErr chan error) {
 		defer close(cErr)
-		log.Info("serving api", "addr", s.cfg.Api.ListeningAddress)
+		log.Info("Serving Api", "addr", s.cfg.Api.ListeningAddress)
 		if err := server.ListenAndServe(); err != nil {
 			log.Error("Failed to serve api", "error", err)
 			cErr <- err


### PR DESCRIPTION
## Motivation

The latency check currently uses the wrong time format (µs instead of seconds).

## Changes

I've changed it to seconds and additionally pulled the timeout assignment out of the go routine since it's unnecessary to assign it every time.

For additional information look at the commits.

## Tests done

Also added another test case for the run unit tests to test multiple targets.

All unit tests still succeed.

## TODO

- [x] I've assigned this PR to myself
- [x] I've labeled this PR correctly

<!-- Add open ToDo's to this checklist -->