### PR TITLE
Refactor: use time.After

### DIFF
--- a/internal/helper/retry.go
+++ b/internal/helper/retry.go
@@ -48,13 +48,10 @@ func Retry(effector Effector, rc RetryConfig) func(ctx context.Context) error {
 			delay := getExpBackoff(rc.Delay, r)
 			log.WarnContext(ctx, fmt.Sprintf("Effector call failed, retrying in %v", delay))
 
-			timer := time.NewTimer(delay)
-			defer timer.Stop() //nolint:gocritic //TODO: check if this is correct
-
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
-			case <-timer.C:
+			case <-time.After(delay):
 			}
 		}
 	}

--- a/pkg/config/http.go
+++ b/pkg/config/http.go
@@ -68,13 +68,10 @@ func (gl *HttpLoader) Run(ctx context.Context) {
 		log.Info("Successfully got remote runtime configuration")
 		gl.cCfgChecks <- runtimeCfg.Checks
 
-		timer := time.NewTimer(gl.cfg.Loader.Interval)
-		defer timer.Stop() //nolint:gocritic // TODO: check if this is right
-
 		select {
 		case <-ctx.Done():
 			return
-		case <-timer.C:
+		case <-time.After(gl.cfg.Loader.Interval):
 		}
 	}
 }


### PR DESCRIPTION
## Motivation

Closes #35 

## Changes

Change time.Timer uses to time.After in http.go and retry.go

For additional information look at the commits.

## Tests done

<!-- Explain what tests you've done and if your tests worked -->

## TODO

- [x] I've assigned this PR to myself
- [x] I've labeled this PR correctly

<!-- Add open ToDo's to this checklist -->