### PR TITLE
feat/target-manager-shutdown

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -20,6 +20,7 @@ package cmd
 
 import (
 	"context"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -116,7 +117,10 @@ func run(fm *config.RunFlagsNameMapping) func(cmd *cobra.Command, args []string)
 		s := sparrow.New(cfg)
 		log.Info("Running sparrow")
 		if err := s.Run(ctx); err != nil {
-			panic(err)
+			log.Error("Error while running sparrow", "error", err)
+			// by this time all shutdown routines should have been called
+			// so we can exit here
+			os.Exit(1)
 		}
 	}
 }

--- a/pkg/sparrow/api.go
+++ b/pkg/sparrow/api.go
@@ -40,7 +40,6 @@ type encoder interface {
 const (
 	urlParamCheckName = "checkName"
 	readHeaderTimeout = time.Second * 5
-	shutdownTimeout   = time.Second * 5
 )
 
 var (

--- a/pkg/sparrow/gitlab/gitlab.go
+++ b/pkg/sparrow/gitlab/gitlab.go
@@ -35,9 +35,14 @@ import (
 // Gitlab handles interaction with a gitlab repository containing
 // the global targets for the Sparrow instance
 type Gitlab interface {
+	// FetchFiles fetches the files from the global targets repository
 	FetchFiles(ctx context.Context) ([]checks.GlobalTarget, error)
+	// PutFile updates the file in the repository
 	PutFile(ctx context.Context, file File) error
+	// PostFile creates the file in the repository
 	PostFile(ctx context.Context, file File) error
+	// DeleteFile deletes the file matching the filename
+	DeleteFile(ctx context.Context, filename string) error
 }
 
 // Client implements Gitlab
@@ -49,6 +54,61 @@ type Client struct {
 	// the token used to authenticate with the gitlab instance
 	token  string
 	client *http.Client
+}
+
+// DeleteFile deletes the file matching the filename from the configured
+// gitlab repository
+func (g *Client) DeleteFile(ctx context.Context, filename string) error {
+	log := logger.FromContext(ctx).With("file", filename)
+
+	if filename == "" {
+		return fmt.Errorf("filename is empty")
+	}
+
+	log.Debug("Deleting file from gitlab")
+	n := url.PathEscape(filename)
+	req, err := http.NewRequestWithContext(ctx,
+		http.MethodDelete,
+		fmt.Sprintf("%s/api/v4/projects/%d/repository/files/%s", g.baseUrl, g.projectID, n),
+		http.NoBody,
+	)
+	if err != nil {
+		log.Error("Failed to create request", "error", err)
+		return err
+	}
+
+	req.Header.Add("PRIVATE-TOKEN", g.token)
+	req.Header.Add("Content-Type", "application/json")
+
+	resp, err := g.client.Do(req) //nolint:bodyclose // closed in defer
+	if err != nil {
+		log.Error("Failed to delete file", "error", err)
+		return err
+	}
+
+	defer func(Body io.ReadCloser) {
+		err = Body.Close()
+		if err != nil {
+			log.Error("Failed to close response body", "error", err)
+		}
+	}(resp.Body)
+
+	if resp.StatusCode != http.StatusNoContent {
+		log.Error("Failed to delete file", "status", resp.Status)
+		return fmt.Errorf("request failed, status is %s", resp.Status)
+	}
+
+	return nil
+}
+
+// File represents a File manipulation operation via the Gitlab API
+type File struct {
+	Branch        string              `json:"branch"`
+	AuthorEmail   string              `json:"author_email"`
+	AuthorName    string              `json:"author_name"`
+	Content       checks.GlobalTarget `json:"content"`
+	CommitMessage string              `json:"commit_message"`
+	fileName      string
 }
 
 func New(baseURL, token string, pid int) Gitlab {
@@ -276,16 +336,6 @@ func (g *Client) PostFile(ctx context.Context, body File) error { //nolint:dupl,
 	}
 
 	return nil
-}
-
-// File represents a File manipulation operation via the Gitlab API
-type File struct {
-	Branch        string              `json:"branch"`
-	AuthorEmail   string              `json:"author_email"`
-	AuthorName    string              `json:"author_name"`
-	Content       checks.GlobalTarget `json:"content"`
-	CommitMessage string              `json:"commit_message"`
-	fileName      string
 }
 
 // Bytes returns the File as a byte array. The Content

--- a/pkg/sparrow/gitlab/gitlab_test.go
+++ b/pkg/sparrow/gitlab/gitlab_test.go
@@ -481,7 +481,14 @@ func TestClient_DeleteFile(t *testing.T) {
 			resp := httpmock.NewStringResponder(tt.mockCode, "")
 			httpmock.RegisterResponder("DELETE", fmt.Sprintf("http://test/api/v4/projects/%d/repository/files/%s", projID, tt.fileName), resp)
 
-			if err := g.DeleteFile(context.Background(), tt.fileName); (err != nil) != tt.wantErr {
+			f := File{
+				fileName:      tt.fileName,
+				CommitMessage: "Deleted registration file",
+				AuthorName:    "sparrow-test",
+				AuthorEmail:   "sparrow-test@sparrow",
+				Branch:        "main",
+			}
+			if err := g.DeleteFile(context.Background(), f); (err != nil) != tt.wantErr {
 				t.Fatalf("DeleteFile() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/pkg/sparrow/gitlab/test/mockclient.go
+++ b/pkg/sparrow/gitlab/test/mockclient.go
@@ -73,6 +73,11 @@ func (m *MockClient) SetPostFileErr(err error) {
 	m.postFileErr = err
 }
 
+// SetDeleteFileErr sets the error returned by DeleteFile
+func (m *MockClient) SetDeleteFileErr(err error) {
+	m.deleteFileErr = err
+}
+
 // New creates a new MockClient to mock Gitlab interaction
 func New(targets []checks.GlobalTarget) *MockClient {
 	return &MockClient{

--- a/pkg/sparrow/gitlab/test/mockclient.go
+++ b/pkg/sparrow/gitlab/test/mockclient.go
@@ -31,6 +31,7 @@ type MockClient struct {
 	fetchFilesErr error
 	putFileErr    error
 	postFileErr   error
+	deleteFileErr error
 }
 
 func (m *MockClient) PutFile(ctx context.Context, _ gitlab.File) error { //nolint: gocritic // irrelevant
@@ -49,6 +50,12 @@ func (m *MockClient) FetchFiles(ctx context.Context) ([]checks.GlobalTarget, err
 	log := logger.FromContext(ctx)
 	log.Info("MockFetchFiles called", "targets", len(m.targets), "err", m.fetchFilesErr)
 	return m.targets, m.fetchFilesErr
+}
+
+func (m *MockClient) DeleteFile(ctx context.Context, fn string) error {
+	log := logger.FromContext(ctx)
+	log.Info("MockDeleteFile called", "filename", fn, "err", m.deleteFileErr)
+	return m.deleteFileErr
 }
 
 // SetFetchFilesErr sets the error returned by FetchFiles

--- a/pkg/sparrow/gitlab/test/mockclient.go
+++ b/pkg/sparrow/gitlab/test/mockclient.go
@@ -52,9 +52,9 @@ func (m *MockClient) FetchFiles(ctx context.Context) ([]checks.GlobalTarget, err
 	return m.targets, m.fetchFilesErr
 }
 
-func (m *MockClient) DeleteFile(ctx context.Context, fn string) error {
+func (m *MockClient) DeleteFile(ctx context.Context, file gitlab.File) error { //nolint: gocritic // irrelevant
 	log := logger.FromContext(ctx)
-	log.Info("MockDeleteFile called", "filename", fn, "err", m.deleteFileErr)
+	log.Info("MockDeleteFile called", "filename", file, "err", m.deleteFileErr)
 	return m.deleteFileErr
 }
 

--- a/pkg/sparrow/targets/gitlab.go
+++ b/pkg/sparrow/targets/gitlab.go
@@ -34,6 +34,8 @@ import (
 
 var _ TargetManager = &gitlabTargetManager{}
 
+const shutdownTimeout = 30 * time.Second
+
 // gitlabTargetManager implements TargetManager
 type gitlabTargetManager struct {
 	targets []checks.GlobalTarget
@@ -86,7 +88,9 @@ func (t *gitlabTargetManager) Reconcile(ctx context.Context) {
 		case <-ctx.Done():
 			if err := ctx.Err(); err != nil {
 				log.Error("Context canceled", "error", err)
-				err = t.Shutdown(ctx)
+				ctxS, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+				defer cancel() //nolint: gocritic // how else can we defer a cancel?
+				err = t.Shutdown(ctxS)
 				if err != nil {
 					log.Error("Failed to shutdown gracefully, stopping routine", "error", err)
 					return
@@ -127,7 +131,14 @@ func (t *gitlabTargetManager) Shutdown(ctx context.Context) error {
 	log.Debug("Shut down signal received")
 
 	if t.Registered() {
-		err := t.gitlab.DeleteFile(ctx, fmt.Sprintf("%s.json", t.name))
+		f := gitlab.File{
+			Branch:        "main",
+			AuthorEmail:   fmt.Sprintf("%s@sparrow", t.name),
+			AuthorName:    t.name,
+			CommitMessage: "Unregistering global target",
+		}
+		f.SetFileName(fmt.Sprintf("%s.json", t.name))
+		err := t.gitlab.DeleteFile(ctx, f)
 		if err != nil {
 			log.Error("Failed to shutdown gracefully", "error", err)
 			return err


### PR DESCRIPTION
⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️
⚠️ Review after #50  ⚠️
⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

## Motivation

Last thing to do for https://github.com/caas-team/sparrow/issues/30 is to make sure a sparrow tries to unregister itself if shutdown.

## Changes

- Implemented the shutdown procedure for the target manager
- removed a whole lot of panics which stopped the sparrow from shutting down properly

For additional information look at the commits.

## Tests done

- [x] New unittests
- [x] E2E test with a main context with a short timeout, to test a cancelled timeout, which would trigger the shutdown functions.

### E2E Tests with shutdown

Logs:

```
/home/bbressi/.cache/JetBrains/GoLand2023.3/tmp/GoLand/___remote_check_config run --config ./.tmp/sparrow.yaml --tmconfig ./.tmp/tmconfig.yaml
Using config file: ./.tmp/sparrow.yaml
{"time":"2023-12-20T10:32:11.534374502+01:00","level":"INFO","msg":"Running sparrow"}
{"time":"2023-12-20T10:32:11.534568139+01:00","level":"INFO","msg":"Serving Api","sparrow":{"api":{"addr":":8080"}}}
{"time":"2023-12-20T10:32:11.534818472+01:00","level":"INFO","msg":"Starting global gitlabTargetManager reconciler"}
{"time":"2023-12-20T10:32:11.731858215+01:00","level":"INFO","msg":"Successfully got remote runtime configuration"}
{"time":"2023-12-20T10:32:11.732110322+01:00","level":"INFO","msg":"Next health check will run after delay","sparrow":{"health":{"delay":"15s"}}}
{"time":"2023-12-20T10:32:11.732130862+01:00","level":"INFO","msg":"Using latency check interval of 1s"}
{"time":"2023-12-20T10:32:15.734814109+01:00","level":"ERROR","msg":"Error while checking latency","sparrow":{"latency":{"url":"https://example.com/","error":"Get \"https://example.com/\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)"}}}
{"time":"2023-12-20T10:32:21.907126231+01:00","level":"INFO","msg":"Successfully got remote runtime configuration"}
{"time":"2023-12-20T10:32:22.264007233+01:00","level":"INFO","msg":"Successfully fetched all target files","sparrow":{"files":5}}
{"time":"2023-12-20T10:32:26.732242622+01:00","level":"INFO","msg":"Start health check run"}
{"time":"2023-12-20T10:32:27.057723806+01:00","level":"INFO","msg":"Successfully finished health check run"}
{"time":"2023-12-20T10:32:27.057812073+01:00","level":"INFO","msg":"Next health check will run after delay","sparrow":{"health":{"delay":"15s"}}}
{"time":"2023-12-20T10:32:31.534570567+01:00","level":"ERROR","msg":"Failed to run check","sparrow":{"name":"health","error":"context deadline exceeded"}}
{"time":"2023-12-20T10:32:31.534621303+01:00","level":"ERROR","msg":"Failed to serve api","sparrow":{"api":{"error":"http: Server closed"}}}
{"time":"2023-12-20T10:32:31.534655838+01:00","level":"ERROR","msg":"Context canceled","sparrow":{"latency":{"err":"context deadline exceeded"}}}
{"time":"2023-12-20T10:32:31.53466717+01:00","level":"ERROR","msg":"Failed to run check","sparrow":{"name":"latency","error":"context deadline exceeded"}}
{"time":"2023-12-20T10:32:31.534657161+01:00","level":"ERROR","msg":"Api context canceled","sparrow":{"api":{"error":"context deadline exceeded"}}}
{"time":"2023-12-20T10:32:31.534668852+01:00","level":"ERROR","msg":"Context canceled","sparrow":{"error":"context deadline exceeded"}}
{"time":"2023-12-20T10:32:31.534689552+01:00","level":"ERROR","msg":"Error running api server","sparrow":{"error":"api context canceled: context deadline exceeded"}}
{"time":"2023-12-20T10:32:32.31158724+01:00","level":"INFO","msg":"Stopping reconcile routine"}
{"time":"2023-12-20T10:32:32.311657082+01:00","level":"ERROR","msg":"Error while running sparrow","error":"context deadline exceeded"}
{"time":"2023-12-20T10:32:32.311709943+01:00","level":"INFO","msg":"Ending Reconcile routine"}

Process finished with the exit code 1
```

Long history of tests can be seen in the commits of the registration repository as well:

https://gitlab.devops.telekom.de/caas/sparrow/registration/-/commits/main

![image](https://github.com/caas-team/sparrow/assets/52347078/00d64646-ed05-4925-a027-ee998693c66c)


## TODO

- [x] I've assigned this PR to myself
- [x] I've labeled this PR correctly

<!-- Add open ToDo's to this checklist -->