### PR TITLE
feat(helm): add target manager support

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,10 +160,9 @@ Available loader:
 
 ### Runtime
 
-Besides the technical startup configuration the configuration for the `sparrow` checks is loaded dynamically from an
-HTTP endpoint. The `loader` is able to load the configuration dynamically during the runtime. Checks can be enabled,
-disabled and configured. The available loader confutation options for the startup configuration can be found
-in [here](sparrow_run.md)
+In addition to the technical startup configuration, the `sparrow` checks' configuration can be dynamically loaded from an HTTP endpoint during runtime. The `loader` is capable of dynamically loading and configuring checks. You can enable, disable, and configure checks as needed.
+
+For detailed information on available loader configuration options, please refer to [this documentation](docs/sparrow_run.md).
 
 Example format of a runtime configuration:
 
@@ -183,7 +182,7 @@ are listed below and can be set in a startup YAML configuration file (per defaul
 directory).
 
 | Type                                 | Description                                                                          | Default              |
-|--------------------------------------|--------------------------------------------------------------------------------------|----------------------|
+| ------------------------------------ | ------------------------------------------------------------------------------------ | -------------------- |
 | `targetManager.checkInterval`        | The interval in seconds to check for new targets.                                    | `300s`               |
 | `targetManager.unhealthyThreshold`   | The threshold in seconds to mark a target as unhealthy and remove it from the state. | `600s`               |
 | `targetManager.registrationInterval` | The interval in seconds to register the current sparrow at the targets backend.      | `300s`               |
@@ -313,7 +312,7 @@ The application itself and all end-user facing content will be made available in
 The following channels are available for discussions, feedback, and support requests:
 
 | Type       | Channel                                                                                                                                                |
-|------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | **Issues** | <a href="/../../issues/new/choose" title="General Discussion"><img src="https://img.shields.io/github/issues/caas-team/sparrow?style=flat-square"></a> |
 
 ## How to Contribute

--- a/README.md
+++ b/README.md
@@ -8,17 +8,17 @@
 
 - [About this component](#about-this-component)
 - [Installation](#installation)
-    - [Binary](#binary)
-    - [Container Image](#container-image)
-    - [Helm](#helm)
+  - [Binary](#binary)
+  - [Container Image](#container-image)
+  - [Helm](#helm)
 - [Usage](#usage)
-    - [Container Image](#container-image-1)
+  - [Image](#image)
 - [Configuration](#configuration)
-    - [Startup](#startup)
-        - [Loader](#loader)
-    - [Runtime](#runtime)
-    - [TargetManager](#targetmanager)
-    - [Check: Health](#check-health)
+  - [Startup](#startup)
+    - [Loader](#loader)
+  - [Runtime](#runtime)
+  - [Target Manager](#target-manager)
+  - [Check: Health](#check-health)
     - [Health Metrics](#health-metrics)
   - [Check: Latency](#check-latency)
     - [Latency Metrics](#latency-metrics)
@@ -110,12 +110,12 @@ Additionally check out the sparrow [configuration](#configuration) variants.
 
 Use `sparrow run` to execute the instance using the binary. A `sparrowName` (a valid DNS name) is required to be passed, else
 the sparrow will not start:
-    
+
 ```sh
 sparrow run --sparrowName sparrow.telekom.de
 ```
 
-### Container Image
+### Image
 
 Run a `sparrow` container by using e.g. `docker run ghcr.io/caas-team/sparrow`.
 
@@ -184,9 +184,9 @@ directory).
 
 | Type                                 | Description                                                                          | Default              |
 |--------------------------------------|--------------------------------------------------------------------------------------|----------------------|
-| `targetManager.checkInterval`        | The interval in seconds to check for new targets.                                    | `300`                |
-| `targetManager.unhealthyThreshold`   | The threshold in seconds to mark a target as unhealthy and remove it from the state. | `600`                |
-| `targetManager.registrationInterval` | The interval in seconds to register the current sparrow at the targets backend.      | `300`                |
+| `targetManager.checkInterval`        | The interval in seconds to check for new targets.                                    | `300s`               |
+| `targetManager.unhealthyThreshold`   | The threshold in seconds to mark a target as unhealthy and remove it from the state. | `600s`               |
+| `targetManager.registrationInterval` | The interval in seconds to register the current sparrow at the targets backend.      | `300s`               |
 | `targetManager.gitlab.token`         | The token to authenticate against the gitlab instance.                               | `""`                 |
 | `targetManager.gitlab.baseUrl`       | The base URL of the gitlab instance.                                                 | `https://gitlab.com` |
 | `targetManager.gitlab.projectId`     | The project ID of the gitlab project to use as a remote state backend.               | `""`                 |
@@ -229,28 +229,28 @@ checks:
 #### Health Metrics
 
 - `sparrow_health_up`
-    - Type: Gauge
-    - Description: Health of targets
-    - Labelled with `target`
+  - Type: Gauge
+  - Description: Health of targets
+  - Labelled with `target`
 
 ### Check: Latency
 
 Available configuration options:
 
 - `checks`
-    - `latency`
-        - `enabled` (boolean): Currently not used.
-        - `interval` (integer): Interval in seconds to perform the latency check.
-        - `timeout` (integer): Timeout in seconds for the latency check.
-        - `retry`
-            - `count` (integer): Number of retries for the latency check.
-            - `delay` (integer): Delay in seconds between retries for the latency check.
-        - `targets` (list of strings): List of targets to send latency probe. Needs to be a valid url. Can be
-          another `sparrow` instance. Use latency endpoint, e.g. `https://sparrow-dns.telekom.de/checks/latency`. The
-          remote `sparrow` instance needs the `latencyEndpoint` enabled.
-        - `latencyEndpoint` (boolean): Needs to be activated when the `sparrow` should expose its own latency endpoint.
-          Mandatory if another `sparrow` instance wants to perform a latency check.
-          Example configuration:
+  - `latency`
+    - `enabled` (boolean): Currently not used.
+    - `interval` (integer): Interval in seconds to perform the latency check.
+    - `timeout` (integer): Timeout in seconds for the latency check.
+    - `retry`
+      - `count` (integer): Number of retries for the latency check.
+      - `delay` (integer): Delay in seconds between retries for the latency check.
+    - `targets` (list of strings): List of targets to send latency probe. Needs to be a valid url. Can be
+      another `sparrow` instance. Use latency endpoint, e.g. `https://sparrow-dns.telekom.de/checks/latency`. The
+      remote `sparrow` instance needs the `latencyEndpoint` enabled.
+    - `latencyEndpoint` (boolean): Needs to be activated when the `sparrow` should expose its own latency endpoint.
+      Mandatory if another `sparrow` instance wants to perform a latency check.
+      Example configuration:
 
 ```yaml
 checks:
@@ -269,19 +269,19 @@ checks:
 #### Latency Metrics
 
 - `sparrow_latency_duration_seconds`
-    - Type: Gauge
-    - Description: Latency with status information of targets
-    - Labelled with `target` and `status`
+  - Type: Gauge
+  - Description: Latency with status information of targets
+  - Labelled with `target` and `status`
 
 - `sparrow_latency_count`
-    - Type: Counter
-    - Description: Count of latency checks done
-    - Labelled with `target`
+  - Type: Counter
+  - Description: Count of latency checks done
+  - Labelled with `target`
 
 - `sparrow_latency_duration`
-    - Type: Histogram
-    - Description: Latency of targets in seconds
-    - Labelled with `target`
+  - Type: Histogram
+  - Description: Latency of targets in seconds
+  - Labelled with `target`
 
 ## API
 

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart to install Sparrow
 type: application
 keywords:
   - monitoring
-version: 0.0.2
-appVersion: "v0.1.0"
+version: 0.0.3
+appVersion: "v0.2.0"
 icon: https://github.com/caas-team/sparrow/blob/main/docs/img/sparrow.png
 sources:
   - https://github.com/caas-team/sparrow

--- a/chart/README.md
+++ b/chart/README.md
@@ -1,6 +1,6 @@
 # sparrow
 
-![Version: 0.0.2](https://img.shields.io/badge/Version-0.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.0.3](https://img.shields.io/badge/Version-0.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.0](https://img.shields.io/badge/AppVersion-v0.2.0-informational?style=flat-square)
 
 A Helm chart to install Sparrow
 

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -60,9 +60,3 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
-
-{{- define "startupConfig" -}}
-{{- range $key, $value := .Values.startupConfig }}
-{{ $key }}: {{ $value }}
-{{- end }}
-{{- end }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -36,6 +36,8 @@ spec:
           {{- if .Values.startupConfig}}
           - --config
           - /startupconfig/.sparrow.yaml
+          - --tmconfig 
+          - /startupconfig/tmconfig.yaml
           {{- else if .Values.extraArgs }}
           {{- range $key, $value := .Values.extraArgs }}
           - --{{ $key }}

--- a/chart/templates/secret.yaml
+++ b/chart/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.startupConfig}}
+{{- if or .Values.startupConfig .Values.targetManagerConfig }}
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -7,5 +7,10 @@ metadata:
   labels:
     {{- include "sparrow.labels" . | nindent 4 }}
 data:
-  .sparrow.yaml: {{ include "startupConfig" . | b64enc }}
+  {{- if .Values.startupConfig}}
+  .sparrow.yaml: {{ toYaml .Values.startupConfig | b64enc }}
+  {{- end }}
+  {{- if .Values.targetManagerConfig}}
+  tmconfig.yaml: {{ toYaml .Values.targetManagerConfig | b64enc }}
+  {{- end }}
 {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -112,6 +112,16 @@ extraArgs:
 #   loaderInterval:
 #   loaderType: http | file
 
+# -- target manager configuration of the Sparrow (part of the startup)
+# targetManagerConfig:
+#   checkInterval: 300s
+#   unhealthyThreshold: 600s
+#   registrationInterval: 300s
+#   gitlab:
+#     token: ""
+#     baseUrl: https://gitlab.com
+#     projectId: ""
+
 # -- runtime configuration of the Sparrow
 # see: https://github.com/caas-team/sparrow#runtime
 runtimeConfig:


### PR DESCRIPTION
## Motivation

With `v0.2.0` we have introduced the target manager. Therefore we needed to upgrade the helm chart. Here we go... 

## Changes

<!-- Explain what you've changed -->

For additional information look at the commits.

## Tests done

<!-- Explain what tests you've done and if your tests worked -->
- deployed in k8s env
- E2E will fail. It needs to be refactored. Option to diable the target manager will be done with https://github.com/caas-team/sparrow/issues/55
