### PR TITLE
feat: always activate health endpoint; rm unnecessary config

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ apiVersion: 0.0.1
 kind: Config
 checks:
   health:
-    enabled: true
+    targets: []
 ```
 
 ### Target Manager
@@ -207,22 +207,16 @@ which is named after the DNS name of the `sparrow`. The state file contains the 
 
 Available configuration options:
 
-- `checks.health.enabled` (boolean): Currently not used.
 - `checks.health.targets` (list of strings): List of targets to send health probe. Needs to be a valid url. Can be
-  another `sparrow` instance. Use health endpoint, e.g. `https://sparrow-dns.telekom.de/checks/health`. The
-  remote `sparrow` instance needs the `healthEndpoint` enabled.
-- `checks.health.healthEndpoint` (boolean): Needs to be activated when the `sparrow` should expose its own health
-  endpoint. Mandatory if another `sparrow` instance wants to perform a health check.
+  another `sparrow` instance. Automatically used when target manager is activated otherwise use the health endpoint of the remote sparrow, e.g. `https://sparrow-dns.telekom.de/checks/health`.
 
 Example configuration:
 
 ```YAML
 checks:
   health:
-    enabled: true
     targets:
       - "https://gitlab.devops.telekom.de"
-    healthEndpoint: false
 ```
 
 #### Health Metrics
@@ -238,15 +232,14 @@ Available configuration options:
 
 - `checks`
   - `latency`
-    - `enabled` (boolean): Currently not used.
     - `interval` (integer): Interval in seconds to perform the latency check.
     - `timeout` (integer): Timeout in seconds for the latency check.
     - `retry`
       - `count` (integer): Number of retries for the latency check.
       - `delay` (integer): Delay in seconds between retries for the latency check.
     - `targets` (list of strings): List of targets to send latency probe. Needs to be a valid url. Can be
-      another `sparrow` instance. Use latency endpoint, e.g. `https://sparrow-dns.telekom.de/checks/latency`. The
-      remote `sparrow` instance needs the `latencyEndpoint` enabled.
+      another `sparrow` instance. Automatically used when the target manager is enabled otherwise
+      use latency endpoint, e.g. `https://sparrow-dns.telekom.de/checks/latency`.
     - `latencyEndpoint` (boolean): Needs to be activated when the `sparrow` should expose its own latency endpoint.
       Mandatory if another `sparrow` instance wants to perform a latency check.
       Example configuration:
@@ -254,7 +247,6 @@ Available configuration options:
 ```yaml
 checks:
   latency:
-    enabled: true
     interval: 1
     timeout: 3
     retry:

--- a/chart/README.md
+++ b/chart/README.md
@@ -43,7 +43,7 @@ A Helm chart to install Sparrow
 | podSecurityContext.supplementalGroups[0] | int | `1000` |  |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
-| runtimeConfig | object | `{"health":{"enabled":true,"healthEndpoint":false,"targets":["https://www.example.com/","https://www.google.com/"]},"latency":{"enabled":true,"interval":1,"retry":{"count":3,"delay":1},"targets":["https://example.com/","https://google.com/"],"timeout":3}}` | runtime configuration of the Sparrow see: https://github.com/caas-team/sparrow#runtime |
+| runtimeConfig | object | `{"health":{"targets":["https://www.example.com/","https://www.google.com/"]},"latency":{"interval":1,"retry":{"count":3,"delay":1},"targets":["https://example.com/","https://google.com/"],"timeout":3}}` | runtime configuration of the Sparrow see: https://github.com/caas-team/sparrow#runtime |
 | securityContext.allowPrivilegeEscalation | bool | `false` |  |
 | securityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | securityContext.privileged | bool | `false` |  |

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -12,16 +12,13 @@ data:
     checks:
       {{- if .Values.runtimeConfig.health}}
       health:
-        enabled: {{ .Values.runtimeConfig.health.enabled }}
         targets:
         {{- with .Values.runtimeConfig.health.targets }}
           {{- toYaml . | nindent 10 }}
         {{- end }}
-        healthEndpoint: {{ .Values.runtimeConfig.health.healthEndpoint  }}
       {{- end }}
       {{- if .Values.runtimeConfig.latency }}
       latency:
-        enabled: true
         interval: {{ .Values.runtimeConfig.latency.interval | default 1 }}
         timeout: {{ .Values.runtimeConfig.latency.timeout | default 3 }}
         retry:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -126,13 +126,10 @@ extraArgs:
 # see: https://github.com/caas-team/sparrow#runtime
 runtimeConfig:
   health:
-    enabled: true
     targets:
       - "https://www.example.com/"
       - "https://www.google.com/"
-    healthEndpoint: false
   latency:
-    enabled: true
     interval: 1
     timeout: 3
     retry:

--- a/pkg/checks/health.go
+++ b/pkg/checks/health.go
@@ -49,9 +49,7 @@ type Health struct {
 
 // HealthConfig contains the health check config
 type HealthConfig struct {
-	Enabled        bool     `json:"enabled,omitempty"`
-	Targets        []string `json:"targets,omitempty"`
-	HealthEndpoint bool     `json:"healthEndpoint,omitempty"`
+	Targets []string `json:"targets,omitempty"`
 }
 
 // Data that will be stored in the database
@@ -144,17 +142,14 @@ func (h *Health) Schema() (*openapi3.SchemaRef, error) {
 }
 
 // RegisterHandler dynamically registers a server handler
-// if it is enabled by the config
 func (h *Health) RegisterHandler(ctx context.Context, router *api.RoutingTree) {
 	log := logger.FromContext(ctx)
-	if h.config.HealthEndpoint {
-		router.Add(http.MethodGet, h.route, func(w http.ResponseWriter, _ *http.Request) {
-			_, err := w.Write([]byte("ok"))
-			if err != nil {
-				log.Error("Could not write response", "error", err.Error())
-			}
-		})
-	}
+	router.Add(http.MethodGet, h.route, func(w http.ResponseWriter, _ *http.Request) {
+		_, err := w.Write([]byte("ok"))
+		if err != nil {
+			log.Error("Could not write response", "error", err.Error())
+		}
+	})
 }
 
 // DeregisterHandler dynamically deletes the server handler

--- a/pkg/checks/health_test.go
+++ b/pkg/checks/health_test.go
@@ -40,42 +40,32 @@ func TestHealth_SetConfig(t *testing.T) {
 		{
 			name: "simple config",
 			inputConfig: map[string]any{
-				"enabled": true,
 				"targets": []any{
 					"test",
 				},
-				"healthEndpoint": true,
 			},
 			expectedConfig: HealthConfig{
-				Enabled: true,
 				Targets: []string{
 					"test",
 				},
-				HealthEndpoint: true,
 			},
 			wantErr: false,
 		},
 		{
-			name: "missing config field",
-			inputConfig: map[string]any{
-				"healthEndpoint": true,
-			},
+			name:        "missing config field",
+			inputConfig: map[string]any{},
 			expectedConfig: HealthConfig{
-				Enabled:        false,
-				Targets:        nil,
-				HealthEndpoint: true,
+				Targets: nil,
 			},
 			wantErr: false,
 		},
 		{
 			name: "wrong type",
 			inputConfig: map[string]any{
-				"enabled":        "not bool",
-				"target":         "not a slice",
-				"healthEndpoint": true,
+				"target": struct{ name string }{name: "bla"},
 			},
 			expectedConfig: HealthConfig{},
-			wantErr:        true,
+			wantErr:        false,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Motivation

<!-- Explain what motivated you to do these changes -->

The health check endpoint has been configurable. There is no need to enable or disable it. Therefore the config option has been removed. The endpoint is always enabled as soon as the health check is active.

Additionally, the `enabled` config option of the health and latency check was not used at all. Therefor the option has been removed.

## Changes

<!-- Explain what you've changed -->

For additional information look at the commits.