### PR TITLE
feat: global http client

### DIFF
--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -1,0 +1,49 @@
+// sparrow
+// (C) 2024, Deutsche Telekom IT GmbH
+//
+// Deutsche Telekom IT GmbH and all other contributors /
+// copyright owners license this file to you under the Apache
+// License, Version 2.0 (the "License"); you may not use this
+// file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package httpclient
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/caas-team/sparrow/internal/logger"
+)
+
+type client struct{}
+
+// IntoContext embeds the provided http.Client into the given context and returns the modified context.
+// This function is used for passing http clients through context, allowing for easier request handling and client management.
+func IntoContext(ctx context.Context, c *http.Client) context.Context {
+	return context.WithValue(ctx, client{}, c)
+}
+
+// FromContext extracts the http.Client from the provided context.
+// If the context does not have a client it returns http.DefaultClient.
+// This function is useful for retrieving http clients from context in different parts of an application.
+func FromContext(ctx context.Context) *http.Client {
+	log := logger.FromContext(ctx)
+	if ctx != nil {
+		if c, ok := ctx.Value(client{}).(*http.Client); ok {
+			return c
+		}
+	}
+
+	log.Warn("No http.Client found in context; using http.DefaultClient")
+	return http.DefaultClient
+}

--- a/internal/httpclient/client_test.go
+++ b/internal/httpclient/client_test.go
@@ -1,0 +1,99 @@
+// sparrow
+// (C) 2024, Deutsche Telekom IT GmbH
+//
+// Deutsche Telekom IT GmbH and all other contributors /
+// copyright owners license this file to you under the Apache
+// License, Version 2.0 (the "License"); you may not use this
+// file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package httpclient
+
+import (
+	"context"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestIntoContext(t *testing.T) {
+	mockClient := &http.Client{}
+
+	tests := []struct {
+		name    string
+		client  *http.Client
+		wantNil bool
+	}{
+		{
+			name:    "nil client",
+			client:  nil,
+			wantNil: true,
+		},
+		{
+			name:    "valid client",
+			client:  mockClient,
+			wantNil: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := IntoContext(context.Background(), tt.client)
+			if ctx == nil {
+				t.Fatal("IntoContext returned a nil context")
+			}
+
+			c, ok := ctx.Value(client{}).(*http.Client)
+			if !ok && !tt.wantNil {
+				t.Errorf("Expected a client, got none")
+			}
+
+			if !reflect.DeepEqual(c, tt.client) {
+				t.Errorf("Client got = %v, want %v", c, tt.client)
+			}
+		})
+	}
+}
+
+func TestFromContext(t *testing.T) {
+	mockClient := &http.Client{}
+
+	tests := []struct {
+		name      string
+		ctxClient *http.Client
+		want      *http.Client
+	}{
+		{
+			name:      "no client in context",
+			ctxClient: nil,
+			want:      http.DefaultClient,
+		},
+		{
+			name:      "client in context",
+			ctxClient: mockClient,
+			want:      mockClient,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tt.ctxClient != nil {
+				ctx = IntoContext(ctx, tt.ctxClient)
+			}
+
+			if got := FromContext(ctx); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("FromContext() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/checks/checks.go
+++ b/pkg/checks/checks.go
@@ -20,7 +20,6 @@ package checks
 
 import (
 	"context"
-	"net/http"
 	"time"
 
 	"github.com/getkin/kin-openapi/openapi3"
@@ -53,10 +52,6 @@ type Check interface {
 	// This is also called while the check is running, if the remote config is updated
 	// This should return an error if the config is invalid
 	SetConfig(ctx context.Context, config any) error
-	// SetClient sets an HTTP client for the check. This method is used to configure
-	// the check with a specific HTTP client, which can be used for network requests
-	// during the check's execution
-	SetClient(c *http.Client)
 	// Schema returns an openapi3.SchemaRef of the result type returned by the check
 	Schema() (*openapi3.SchemaRef, error)
 	// RegisterHandler Allows the check to register a handler on sparrows http server at runtime

--- a/pkg/checks/checks_moq.go
+++ b/pkg/checks/checks_moq.go
@@ -8,7 +8,6 @@ import (
 	"github.com/caas-team/sparrow/pkg/api"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/prometheus/client_golang/prometheus"
-	"net/http"
 	"sync"
 )
 
@@ -36,9 +35,6 @@ var _ Check = &CheckMock{}
 //			},
 //			SchemaFunc: func() (*openapi3.SchemaRef, error) {
 //				panic("mock out the Schema method")
-//			},
-//			SetClientFunc: func(c *http.Client)  {
-//				panic("mock out the SetClient method")
 //			},
 //			SetConfigFunc: func(ctx context.Context, config any) error {
 //				panic("mock out the SetConfig method")
@@ -70,9 +66,6 @@ type CheckMock struct {
 
 	// SchemaFunc mocks the Schema method.
 	SchemaFunc func() (*openapi3.SchemaRef, error)
-
-	// SetClientFunc mocks the SetClient method.
-	SetClientFunc func(c *http.Client)
 
 	// SetConfigFunc mocks the SetConfig method.
 	SetConfigFunc func(ctx context.Context, config any) error
@@ -110,11 +103,6 @@ type CheckMock struct {
 		// Schema holds details about calls to the Schema method.
 		Schema []struct {
 		}
-		// SetClient holds details about calls to the SetClient method.
-		SetClient []struct {
-			// C is the c argument value.
-			C *http.Client
-		}
 		// SetConfig holds details about calls to the SetConfig method.
 		SetConfig []struct {
 			// Ctx is the ctx argument value.
@@ -140,7 +128,6 @@ type CheckMock struct {
 	lockRegisterHandler     sync.RWMutex
 	lockRun                 sync.RWMutex
 	lockSchema              sync.RWMutex
-	lockSetClient           sync.RWMutex
 	lockSetConfig           sync.RWMutex
 	lockShutdown            sync.RWMutex
 	lockStartup             sync.RWMutex
@@ -301,38 +288,6 @@ func (mock *CheckMock) SchemaCalls() []struct {
 	mock.lockSchema.RLock()
 	calls = mock.calls.Schema
 	mock.lockSchema.RUnlock()
-	return calls
-}
-
-// SetClient calls SetClientFunc.
-func (mock *CheckMock) SetClient(c *http.Client) {
-	if mock.SetClientFunc == nil {
-		panic("CheckMock.SetClientFunc: method is nil but Check.SetClient was just called")
-	}
-	callInfo := struct {
-		C *http.Client
-	}{
-		C: c,
-	}
-	mock.lockSetClient.Lock()
-	mock.calls.SetClient = append(mock.calls.SetClient, callInfo)
-	mock.lockSetClient.Unlock()
-	mock.SetClientFunc(c)
-}
-
-// SetClientCalls gets all the calls that were made to SetClient.
-// Check the length with:
-//
-//	len(mockedCheck.SetClientCalls())
-func (mock *CheckMock) SetClientCalls() []struct {
-	C *http.Client
-} {
-	var calls []struct {
-		C *http.Client
-	}
-	mock.lockSetClient.RLock()
-	calls = mock.calls.SetClient
-	mock.lockSetClient.RUnlock()
 	return calls
 }
 

--- a/pkg/checks/health.go
+++ b/pkg/checks/health.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/caas-team/sparrow/internal/helper"
+	"github.com/caas-team/sparrow/internal/httpclient"
 	"github.com/caas-team/sparrow/internal/logger"
 	"github.com/caas-team/sparrow/pkg/api"
 	"github.com/getkin/kin-openapi/openapi3"
@@ -130,11 +131,6 @@ func (h *Health) SetConfig(_ context.Context, config any) error {
 	return nil
 }
 
-// SetClient sets the http client for the health check
-func (h *Health) SetClient(_ *http.Client) {
-	// TODO: implement with issue #31
-}
-
 // Schema provides the schema of the data that will be provided
 // by the heath check
 func (h *Health) Schema() (*openapi3.SchemaRef, error) {
@@ -237,10 +233,7 @@ func (h *Health) check(ctx context.Context) healthData {
 // returns ok if status code is 200
 func getHealth(ctx context.Context, url string) error {
 	log := logger.FromContext(ctx).With("url", url)
-
-	client := &http.Client{
-		Timeout: time.Second * 5,
-	}
+	c := httpclient.FromContext(ctx)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
 	if err != nil {
@@ -248,7 +241,7 @@ func getHealth(ctx context.Context, url string) error {
 		return err
 	}
 
-	res, err := client.Do(req)
+	res, err := c.Do(req)
 	if err != nil {
 		log.Error("Http get request failed", "error", err.Error())
 		return err

--- a/pkg/checks/latency_test.go
+++ b/pkg/checks/latency_test.go
@@ -134,7 +134,6 @@ func TestLatency_Run(t *testing.T) { //nolint:gocyclo
 				t.Fatalf("Latency.Startup() error = %v", err)
 			}
 
-			c.SetClient(&http.Client{})
 			err = c.SetConfig(tt.ctx, map[string]any{
 				"targets":  tt.targets,
 				"interval": 1,
@@ -292,7 +291,6 @@ func TestLatency_check(t *testing.T) {
 
 			l := &Latency{
 				cfg:     LatencyConfig{Targets: tt.targets, Interval: time.Second * 120, Timeout: time.Second * 1},
-				client:  &http.Client{Transport: httpmock.DefaultTransport},
 				metrics: newLatencyMetrics(),
 			}
 

--- a/pkg/config/http.go
+++ b/pkg/config/http.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/caas-team/sparrow/internal/helper"
+	"github.com/caas-team/sparrow/internal/httpclient"
 	"github.com/caas-team/sparrow/internal/logger"
 	"gopkg.in/yaml.v3"
 )
@@ -80,7 +81,7 @@ func (gl *HttpLoader) Run(ctx context.Context) {
 func (gl *HttpLoader) GetRuntimeConfig(ctx context.Context) (*RuntimeConfig, error) {
 	log := logger.FromContext(ctx).With("url", gl.cfg.Loader.http.url)
 
-	client := http.DefaultClient
+	client := *httpclient.FromContext(ctx)
 	client.Timeout = gl.cfg.Loader.http.timeout
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, gl.cfg.Loader.http.url, http.NoBody)

--- a/pkg/sparrow/gitlab/gitlab.go
+++ b/pkg/sparrow/gitlab/gitlab.go
@@ -28,6 +28,7 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/caas-team/sparrow/internal/httpclient"
 	"github.com/caas-team/sparrow/internal/logger"
 	"github.com/caas-team/sparrow/pkg/checks"
 )
@@ -60,6 +61,7 @@ type Client struct {
 // gitlab repository
 func (g *Client) DeleteFile(ctx context.Context, file File) error { //nolint:gocritic // no performance concerns yet
 	log := logger.FromContext(ctx).With("file", file)
+	client := httpclient.FromContext(ctx)
 
 	if file.fileName == "" {
 		return fmt.Errorf("filename is empty")
@@ -86,7 +88,7 @@ func (g *Client) DeleteFile(ctx context.Context, file File) error { //nolint:goc
 	req.Header.Add("PRIVATE-TOKEN", g.token)
 	req.Header.Add("Content-Type", "application/json")
 
-	resp, err := g.client.Do(req) //nolint:bodyclose // closed in defer
+	resp, err := client.Do(req) //nolint:bodyclose // closed in defer
 	if err != nil {
 		log.Error("Failed to delete file", "error", err)
 		return err
@@ -151,6 +153,8 @@ func (g *Client) FetchFiles(ctx context.Context) ([]checks.GlobalTarget, error) 
 // fetchFile fetches the file from the global targets repository from the configured gitlab repository
 func (g *Client) fetchFile(ctx context.Context, f string) (checks.GlobalTarget, error) {
 	log := logger.FromContext(ctx).With("file", f)
+	client := httpclient.FromContext(ctx)
+
 	var res checks.GlobalTarget
 	// URL encode the name
 	n := url.PathEscape(f)
@@ -166,7 +170,7 @@ func (g *Client) fetchFile(ctx context.Context, f string) (checks.GlobalTarget, 
 	req.Header.Add("PRIVATE-TOKEN", g.token)
 	req.Header.Add("Content-Type", "application/json")
 
-	resp, err := g.client.Do(req) //nolint:bodyclose // closed in defer
+	resp, err := client.Do(req) //nolint:bodyclose // closed in defer
 	if err != nil {
 		log.Error("Failed to fetch file", "error", err)
 		return res, err
@@ -198,6 +202,8 @@ func (g *Client) fetchFile(ctx context.Context, f string) (checks.GlobalTarget, 
 // so they may be fetched individually
 func (g *Client) fetchFileList(ctx context.Context) ([]string, error) {
 	log := logger.FromContext(ctx)
+	client := httpclient.FromContext(ctx)
+
 	log.Debug("Fetching file list from gitlab")
 	type file struct {
 		Name string `json:"name"`
@@ -216,7 +222,7 @@ func (g *Client) fetchFileList(ctx context.Context) ([]string, error) {
 	req.Header.Add("PRIVATE-TOKEN", g.token)
 	req.Header.Add("Content-Type", "application/json")
 
-	resp, err := g.client.Do(req) //nolint:bodyclose // closed in defer
+	resp, err := client.Do(req) //nolint:bodyclose // closed in defer
 	if err != nil {
 		log.Error("Failed to fetch file list", "error", err)
 		return nil, err
@@ -254,6 +260,8 @@ func (g *Client) fetchFileList(ctx context.Context) ([]string, error) {
 // as a global target for other sparrow instances to discover
 func (g *Client) PutFile(ctx context.Context, body File) error { //nolint: dupl,gocritic // no need to refactor yet
 	log := logger.FromContext(ctx)
+	client := httpclient.FromContext(ctx)
+
 	log.Debug("Registering sparrow instance to gitlab")
 
 	// chose method based on whether the registration has already happened
@@ -276,7 +284,7 @@ func (g *Client) PutFile(ctx context.Context, body File) error { //nolint: dupl,
 	req.Header.Add("PRIVATE-TOKEN", g.token)
 	req.Header.Add("Content-Type", "application/json")
 
-	resp, err := g.client.Do(req) //nolint:bodyclose // closed in defer
+	resp, err := client.Do(req) //nolint:bodyclose // closed in defer
 	if err != nil {
 		log.Error("Failed to push registration file", "error", err)
 		return err
@@ -301,6 +309,8 @@ func (g *Client) PutFile(ctx context.Context, body File) error { //nolint: dupl,
 // as a global target for other sparrow instances to discover
 func (g *Client) PostFile(ctx context.Context, body File) error { //nolint:dupl,gocritic // no need to refactor yet
 	log := logger.FromContext(ctx)
+	client := httpclient.FromContext(ctx)
+
 	log.Debug("Posting registration file to gitlab")
 
 	// chose method based on whether the registration has already happened
@@ -323,7 +333,7 @@ func (g *Client) PostFile(ctx context.Context, body File) error { //nolint:dupl,
 	req.Header.Add("PRIVATE-TOKEN", g.token)
 	req.Header.Add("Content-Type", "application/json")
 
-	resp, err := g.client.Do(req) //nolint:bodyclose // closed in defer
+	resp, err := client.Do(req) //nolint:bodyclose // closed in defer
 	if err != nil {
 		log.Error("Failed to post file", "error", err)
 		return err

--- a/pkg/sparrow/run_test.go
+++ b/pkg/sparrow/run_test.go
@@ -20,7 +20,6 @@ package sparrow
 
 import (
 	"context"
-	"net/http"
 	"reflect"
 	"testing"
 	"time"
@@ -60,7 +59,6 @@ func TestSparrow_ReconcileChecks(t *testing.T) {
 		},
 		RegisterHandlerFunc:   func(ctx context.Context, router *api.RoutingTree) {},
 		DeregisterHandlerFunc: func(ctx context.Context, router *api.RoutingTree) {},
-		SetClientFunc:         func(c *http.Client) {},
 		GetMetricCollectorsFunc: func() []prometheus.Collector {
 			return []prometheus.Collector{}
 		},


### PR DESCRIPTION
## Motivation

To enhance the flexibility and maintainability of the HTTP client configuration across various components of the sparrow, I've adopted a context-based approach for managing the HTTP client. This allows the checks, the loader, and the Gitlab manager to customize their client configurations such as timeouts without affecting other parts of the system. This approach also simplifies the Sparrow struct by not including the HTTP client directly, thus adhering to the principles of separation of concerns and reducing coupling.

## Changes

- Implemented a context-based HTTP client management system across all checks, the HTTP loader, and the Gitlab manager.
- Chose not to add the HTTP client directly to the Sparrow struct. This decision was made to keep the Sparrow struct focused on its core responsibilities.
- When a client configuration needs to be changed (e.g., adjusting the timeout), the HTTP client is dereferenced after retrieval from the context. This creates a copy of the client that can be safely modified without causing race conditions or affecting other operations using the client.

For additional information, look at the commits.

## Tests done

- [x] Unit tests succeeded
- [ ] E2E test succeeded

## TODO

- [x] I've assigned this PR to myself
- [x] I've labeled this PR correctly
