### PR TITLE
fix: only include json files in gtm file list

### DIFF
--- a/pkg/sparrow/gitlab/gitlab.go
+++ b/pkg/sparrow/gitlab/gitlab.go
@@ -135,7 +135,7 @@ func (g *Client) FetchFiles(ctx context.Context) ([]checks.GlobalTarget, error) 
 		log.Error("Failed to fetch files", "error", err)
 		return nil, err
 	}
-	// TODO: pop all non json files from fl
+
 	var result []checks.GlobalTarget
 	for _, f := range fl {
 		gl, err := g.fetchFile(ctx, f)

--- a/pkg/sparrow/gitlab/gitlab.go
+++ b/pkg/sparrow/gitlab/gitlab.go
@@ -27,6 +27,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/caas-team/sparrow/internal/logger"
 	"github.com/caas-team/sparrow/pkg/checks"
@@ -134,7 +135,7 @@ func (g *Client) FetchFiles(ctx context.Context) ([]checks.GlobalTarget, error) 
 		log.Error("Failed to fetch files", "error", err)
 		return nil, err
 	}
-
+	// TODO: pop all non json files from fl
 	var result []checks.GlobalTarget
 	for _, f := range fl {
 		gl, err := g.fetchFile(ctx, f)
@@ -243,7 +244,9 @@ func (g *Client) fetchFileList(ctx context.Context) ([]string, error) {
 
 	var result []string
 	for _, f := range fl {
-		result = append(result, f.Name)
+		if strings.HasSuffix(f.Name, ".json") {
+			result = append(result, f.Name)
+		}
 	}
 
 	log.Debug("Successfully fetched file list", "files", len(result))

--- a/pkg/sparrow/gitlab/gitlab_test.go
+++ b/pkg/sparrow/gitlab/gitlab_test.go
@@ -49,6 +49,17 @@ func Test_gitlab_fetchFileList(t *testing.T) {
 			mockBody: []file{},
 		},
 		{
+			name:     "success - 0 targets with 1 file",
+			want:     nil,
+			wantErr:  false,
+			mockCode: http.StatusOK,
+			mockBody: []file{
+				{
+					Name: "README.md",
+				},
+			},
+		},
+		{
 			name: "success - 1 target",
 			want: []string{
 				"test.json",

--- a/pkg/sparrow/gitlab/gitlab_test.go
+++ b/pkg/sparrow/gitlab/gitlab_test.go
@@ -51,30 +51,30 @@ func Test_gitlab_fetchFileList(t *testing.T) {
 		{
 			name: "success - 1 target",
 			want: []string{
-				"test",
+				"test.json",
 			},
 			wantErr:  false,
 			mockCode: http.StatusOK,
 			mockBody: []file{
 				{
-					Name: "test",
+					Name: "test.json",
 				},
 			},
 		},
 		{
 			name: "success - 2 targets",
 			want: []string{
-				"test",
-				"test2",
+				"test.json",
+				"test2.json",
 			},
 			wantErr:  false,
 			mockCode: http.StatusOK,
 			mockBody: []file{
 				{
-					Name: "test",
+					Name: "test.json",
 				},
 				{
-					Name: "test2",
+					Name: "test2.json",
 				},
 			},
 		},
@@ -144,7 +144,7 @@ func Test_gitlab_FetchFiles(t *testing.T) {
 			},
 			fileList: []file{
 				{
-					Name: "test",
+					Name: "test.json",
 				},
 			},
 			wantErr:  false,
@@ -164,10 +164,10 @@ func Test_gitlab_FetchFiles(t *testing.T) {
 			},
 			fileList: []file{
 				{
-					Name: "test",
+					Name: "test.json",
 				},
 				{
-					Name: "test2",
+					Name: "test2.json",
 				},
 			},
 			wantErr:  false,


### PR DESCRIPTION
## Motivation

If the gitlab repo has any other files than `.json`, we get an error.

## Changes

I've added a filter to only include `.json` files to the file list

For additional information look at the commits.

## Tests done

I've added a unit test for it.

- [x] Unit tests succeeded

## TODO

- [x] I've assigned this PR to myself
- [x] I've labeled this PR correctly

<!-- Add open ToDo's to this checklist -->