### PR TITLE
feat: Service Monitor

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -56,10 +56,11 @@ A Helm chart to install Sparrow
 | serviceAccount.automount | bool | `true` | Automatically mount a ServiceAccount's API credentials? |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
-| serviceMonitor.enabled | bool | `false` |  |
-| serviceMonitor.interval | string | `"30s"` |  |
-| serviceMonitor.labels | object | `{}` |  |
-| serviceMonitor.scrapeTimeout | string | `"5s"` |  |
+| serviceMonitor | object | `{"enabled":false,"interval":"30s","labels":{},"scrapeTimeout":"5s"}` | Configure a service monitor for prometheus-operator |
+| serviceMonitor.enabled | bool | `false` | Enable the serviceMonitor |
+| serviceMonitor.interval | string | `"30s"` | Sets the scrape interval |
+| serviceMonitor.labels | object | `{}` | Additional label added to the service Monitor |
+| serviceMonitor.scrapeTimeout | string | `"5s"` | Sets the scrape timeout |
 | startupConfig | object | `{}` | startup configuration of the Sparrow see: https://github.com/caas-team/sparrow/blob/main/docs/sparrow_run.md |
 | tolerations | list | `[]` |  |
 

--- a/chart/README.md
+++ b/chart/README.md
@@ -56,6 +56,10 @@ A Helm chart to install Sparrow
 | serviceAccount.automount | bool | `true` | Automatically mount a ServiceAccount's API credentials? |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| serviceMonitor.enabled | bool | `false` |  |
+| serviceMonitor.interval | string | `"30s"` |  |
+| serviceMonitor.labels | object | `{}` |  |
+| serviceMonitor.scrapeTimeout | string | `"5s"` |  |
 | startupConfig | object | `{}` | startup configuration of the Sparrow see: https://github.com/caas-team/sparrow/blob/main/docs/sparrow_run.md |
 | tolerations | list | `[]` |  |
 

--- a/chart/templates/servicemonitor.yaml
+++ b/chart/templates/servicemonitor.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Release.Name }}-service-monitor
+  labels:
+    app.kubernetes.io/name: {{ include "sparrow.fullname" . }}-service-monitor
+    {{ .Values.serviceMonitor.labels | toYaml | nindent 4 }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+        app.kubernetes.io/name: {{ include "sparrow.fullname" . }}
+  endpoints:
+    - port: http
+      path: /metrics
+      targetPort: http
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -143,3 +143,14 @@ runtimeConfig:
     targets:
       - https://example.com/
       - https://google.com/
+
+# Configure a service monitor for prometheus-operator
+serviceMonitor:
+  # Enable the serviceMonitor
+  enabled: false
+  # Sets the scrape interval
+  interval: 30s
+  # Sets the scrape timeout
+  scrapeTimeout: 5s
+  # Additional label added to the service Monitor
+  labels: {}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -144,13 +144,13 @@ runtimeConfig:
       - https://example.com/
       - https://google.com/
 
-# Configure a service monitor for prometheus-operator
+# -- Configure a service monitor for prometheus-operator
 serviceMonitor:
-  # Enable the serviceMonitor
+  # -- Enable the serviceMonitor
   enabled: false
-  # Sets the scrape interval
+  # -- Sets the scrape interval
   interval: 30s
-  # Sets the scrape timeout
+  # -- Sets the scrape timeout
   scrapeTimeout: 5s
-  # Additional label added to the service Monitor
+  # -- Additional label added to the service Monitor
   labels: {}


### PR DESCRIPTION
## Motivation

Since we're exposing metrics for prometheus, we should also provide a ServiceMonitor, so people who are using the prometheus operator can easily monitor their sparrow instance. 

Closes #52 

## Changes
This PR adds a serviceMonitor to the helm chart, which can optionally be enabled.

<!-- Explain what you've changed -->

For additional information look at the commits.

## Tests done
1. Installed sparrow with the default helm chart in a local kind cluster
2. Rolled out kube-prometheus-stack
3. Provisioned a prometheus instance
4. Enabled the serviceMonitor
5. Profit
![image](https://github.com/caas-team/sparrow/assets/27763017/25f6b723-50b1-4636-86cd-492e705ca7be)
## TODO

- [x] I've assigned this PR to myself
- [x] I've labeled this PR correctly

<!-- Add open ToDo's to this checklist -->