### PR TITLE
feat: package helm chart on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,9 @@ jobs:
         with:
           fetch-tags: true
 
+      - name: List tags
+        run: git tag -l
+
       - name: Get App Version
         id: appVersion
         run:  echo "value=commit-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,9 @@ jobs:
         run: |
           git tag --sort=taggerdate | tail -1 | cut -c 2- 
           echo "value=$(git tag --sort=taggerdate | tail -1 | cut -c 2-)-commit-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+      - name: DEBUG
+        # produces a tag like: 0.2.2-commit-asdf3
+        run: git tag --sort=taggerdate 
       
       - name: Registry login
         run: helm registry login ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,9 +73,6 @@ jobs:
       - name: Fetch tags explicitly
         run: git fetch --tags
 
-      - name: List remotes
-        run: git remote
-
       - name: List tags
         run: git tag -l
 
@@ -86,9 +83,7 @@ jobs:
       - name: Get Chart Version
         id: chartVersion
         # produces a tag like: 0.2.2-commit-asdf3
-        run: |
-          git tag --sort=taggerdate | tail -1 | cut -c 2- 
-          echo "value=$(git describe --tags --abbrev=0)-commit-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+        run: echo "value=$(git tag --sort=taggerdate | tail -1 | cut -c 2-)-commit-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Registry login
         run: helm registry login ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Contiuous Integration
+name: Continuous Integration
 
 on:
   push:
@@ -74,7 +74,7 @@ jobs:
         run: git fetch --tags
 
       - name: List remotes
-        run: git remote ls
+        run: git remote
 
       - name: List tags
         run: git tag -l

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,8 +69,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Get Version
-        id: version
-        run: echo "value=commit-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+        id: appVersion
+        run:  echo "value=commit-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Get Version
+        id: chartVersion
+        # produces a tag like: 0.2.2-commit-asdf3
+        run: echo "values=$(git tag --sort=taggerdate | tail -1 | cut -c 2-)-commit-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       
       - name: Registry login
         run: helm registry login ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
@@ -79,7 +84,7 @@ jobs:
         run: helm lint ./chart
       
       - name: Helm package
-        run: helm package ./chart -d ./chart --version ${{ steps.version.outputs.value }} --app-version ${{ steps.version.outputs.value }}
+        run: helm package ./chart -d ./chart --version ${{ steps.chartVersion.outputs.value }} --app-version ${{ steps.appVersion.outputs.value }}
         
       - name: Push helm package
         run: helm push $(ls ./chart/*.tgz| head -1) oci://ghcr.io/${{ github.repository_owner }}/charts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,14 +68,16 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
 
-      - name: Get Version
+      - name: Get App Version
         id: appVersion
         run:  echo "value=commit-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
-      - name: Get Version
+      - name: Get Chart Version
         id: chartVersion
         # produces a tag like: 0.2.2-commit-asdf3
-        run: echo "value=$(git tag --sort=taggerdate | tail -1 | cut -c 2-)-commit-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+        run: >
+          git tag --sort=taggerdate | tail -1 | cut -c 2- 
+          echo "value=$(git tag --sort=taggerdate | tail -1 | cut -c 2-)-commit-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       
       - name: Registry login
         run: helm registry login ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Get Version
         id: chartVersion
         # produces a tag like: 0.2.2-commit-asdf3
-        run: echo "values=$(git tag --sort=taggerdate | tail -1 | cut -c 2-)-commit-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+        run: echo "value=$(git tag --sort=taggerdate | tail -1 | cut -c 2-)-commit-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       
       - name: Registry login
         run: helm registry login ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,24 @@ jobs:
 
       - name: Push snapshot container image
         run: docker push ghcr.io/caas-team/sparrow:${{ steps.version.outputs.value }}
+  helm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+      - name: Get Version
+        id: version
+        run: echo "value=commit-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+      
+      - name: Registry login
+        run: helm registry login ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Helm lint
+        run: helm lint ./chart
+      
+      - name: Helm package
+        run: helm package ./chart -d ./chart --version ${{ steps.version.outputs.value }} --app-version ${{ steps.version.outputs.value }}
+        
+      - name: Push helm package
+        run: helm push $(ls ./chart/*.tgz| head -1) oci://ghcr.io/${{ github.repository_owner }}/charts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,12 @@ jobs:
         with:
           fetch-tags: true
 
+      - name: Fetch tags explicitly
+        run: git fetch --tags
+
+      - name: List remotes
+        run: git remote ls
+
       - name: List tags
         run: git tag -l
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Get Chart Version
         id: chartVersion
         # produces a tag like: 0.2.2-commit-asdf3
-        run: >
+        run: |
           git tag --sort=taggerdate | tail -1 | cut -c 2- 
           echo "value=$(git tag --sort=taggerdate | tail -1 | cut -c 2-)-commit-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,9 +73,6 @@ jobs:
       - name: Fetch tags explicitly
         run: git fetch --tags
 
-      - name: List tags
-        run: git tag -l
-
       - name: Get App Version
         id: appVersion
         run:  echo "value=commit-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          fetch-tags: true
 
       - name: Get App Version
         id: appVersion
@@ -78,10 +80,7 @@ jobs:
         run: |
           git tag --sort=taggerdate | tail -1 | cut -c 2- 
           echo "value=$(git describe --tags --abbrev=0)-commit-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-      - name: DEBUG
-        # produces a tag like: 0.2.2-commit-asdf3
-        run: git describe --tags --abbrev=0
-      
+
       - name: Registry login
         run: helm registry login ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,10 +77,10 @@ jobs:
         # produces a tag like: 0.2.2-commit-asdf3
         run: |
           git tag --sort=taggerdate | tail -1 | cut -c 2- 
-          echo "value=$(git tag --sort=taggerdate | tail -1 | cut -c 2-)-commit-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "value=$(git describe --tags --abbrev=0)-commit-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: DEBUG
         # produces a tag like: 0.2.2-commit-asdf3
-        run: git tag --sort=taggerdate 
+        run: git describe --tags --abbrev=0
       
       - name: Registry login
         run: helm registry login ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Motivation

Since we build and publish a docker image for every pr and main push, we should do the same thing for the helm chart.

```bash
❯ helm show chart  oci://ghcr.io/caas-team/charts/sparrow --version 0.2.2-commit-3158f2d
Pulled: ghcr.io/caas-team/charts/sparrow:0.2.2-commit-3158f2d
Digest: sha256:4711bb41a28e0f17ab63faa2890a6c5f4f63822b50413ecaa9be94f23cb86f37

```

```yaml
apiVersion: v2
appVersion: commit-3158f2d
description: A Helm chart to install Sparrow
icon: 'https://github.com/caas-team/sparrow/blob/main/docs/img/sparrow.png'
keywords:
  - monitoring
maintainers:
  - email: f.kloeker@telekom.de
    name: eumel8
    url: 'https://www.telekom.com'
  - email: maximilian.schubert@telekom.de
    name: y-eight
    url: 'https://www.telekom.com'
name: sparrow
sources:
  - 'https://github.com/caas-team/sparrow'
type: application
version: 0.2.2-commit-3158f2d

```

## Changes

Packages the helm chart in the ci workflow on every pr and main commit, and releases it with its version and appVersion set to commit-<GIT_SHORT_SHA>. Ensures that, whenever we build a new docker image, we also have a helm chart available.

For additional information look at the commits.

## Tests done

- [x] ran pipeline
- [x] `helm upgrade -n sparrow sparrow oci://ghcr.io/caas-team/charts/sparrow --version 0.2.2-commit-3158f2d` resulted in image ghcr.io/caas-team/sparrow:commit-3158f2d being used, as expected
<!-- Explain what tests you've done and if your tests worked -->

## TODO

- [x] I've assigned this PR to myself
- [x] I've labeled this PR correctly

<!-- Add open ToDo's to this checklist -->