### PR TITLE
feat: simplify helm chart

### DIFF
--- a/.github/workflows/end2end.yml
+++ b/.github/workflows/end2end.yml
@@ -53,14 +53,15 @@ jobs:
       run: echo "value=commit-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
     - name: Install Sparrow
       run: |
-        helm upgrade -i sparrow \
+        helm upgrade -i sparrow -n sparrow \
           --atomic \
           --timeout 300s \
-          --set extraArgs.loaderType=file \
-          --set extraArgs.loaderFilePath=/runconfig/checks.yaml \
-          --set image.tag=${{ steps.version.outputs.value }} \
-          --set startupConfig.name=the-sparrow.com \
-          chart
+          --set image.tag=${{ steps.version.outputs.value }}  \
+          --set config.name=the-sparrow.com \
+          --set config.loader.type=file \
+          --set config.loader.file.path=/config/.sparrow.yaml \
+          ./chart
+
     - name: Check Pods
       run: |
         kubectl get pods

--- a/chart/README.md
+++ b/chart/README.md
@@ -20,8 +20,9 @@ A Helm chart to install Sparrow
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
+| config | object | `{}` | startup configuration of the Sparrow see: https://github.com/caas-team/sparrow/blob/main/docs/sparrow_run.md |
 | env | object | `{}` |  |
-| extraArgs | object | `{"loaderFilePath":"/runconfig/checks.yaml","loaderType":"file"}` | extra command line start parameters see: https://github.com/caas-team/sparrow/blob/main/docs/sparrow_run.md |
+| extraArgs | object | `{}` | extra command line start parameters see: https://github.com/caas-team/sparrow/blob/main/docs/sparrow_run.md |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"ghcr.io/caas-team/sparrow"` |  |
@@ -43,7 +44,6 @@ A Helm chart to install Sparrow
 | podSecurityContext.supplementalGroups[0] | int | `1000` |  |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
-| runtimeConfig | object | `{}` | runtime configuration of the Sparrow see: https://github.com/caas-team/sparrow#runtime |
 | securityContext.allowPrivilegeEscalation | bool | `false` |  |
 | securityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | securityContext.privileged | bool | `false` |  |
@@ -61,6 +61,5 @@ A Helm chart to install Sparrow
 | serviceMonitor.interval | string | `"30s"` | Sets the scrape interval |
 | serviceMonitor.labels | object | `{}` | Additional label added to the service Monitor |
 | serviceMonitor.scrapeTimeout | string | `"5s"` | Sets the scrape timeout |
-| startupConfig | object | `{}` | startup configuration of the Sparrow see: https://github.com/caas-team/sparrow/blob/main/docs/sparrow_run.md |
 | tolerations | list | `[]` |  |
 

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.runtimeConfig}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,32 +5,5 @@ metadata:
   labels:
     {{- include "sparrow.labels" . | nindent 4 }}
 data:
-  checks.yaml: |
-    apiVersion: 0.0.1
-    kind: Config
-    checks:
-      {{- if .Values.runtimeConfig.health}}
-      health:
-        interval: {{ .Values.runtimeConfig.health.interval | default "1s" }}
-        timeout: {{ .Values.runtimeConfig.health.interval | default "3s" }}
-        retry:
-          count: {{ .Values.runtimeConfig.health.retry.count | default 3 }}
-          delay: {{ .Values.runtimeConfig.health.retry.delay | default "1s" }}
-        targets:
-        {{- with .Values.runtimeConfig.health.targets }}
-          {{- toYaml . | nindent 10 }}
-        {{- end }}
-      {{- end }}
-      {{- if .Values.runtimeConfig.latency }}
-      latency:
-        interval: {{ .Values.runtimeConfig.latency.interval | default "1s" }}
-        timeout: {{ .Values.runtimeConfig.latency.timeout | default "3s" }}
-        retry:
-          count: {{ .Values.runtimeConfig.latency.retry.count | default 3 }}
-          delay: {{ .Values.runtimeConfig.latency.retry.delay | default "1s" }}
-        targets:
-        {{- with .Values.runtimeConfig.latency.targets }}
-          {{- toYaml . | nindent 10 }}
-        {{- end }}
-      {{- end }}
-{{- end }}
+  .sparrow.yaml: |
+	{{- .Values.config | toYaml | nindent 4 }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -30,13 +30,9 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        {{- if or .Values.extraArgs .Values.startupConfig }}
         - args:
-        {{- end }}
-          {{- if .Values.startupConfig}}
             - --config
-            - /startupconfig/.sparrow.yaml
-          {{- end }}
+            - /config/.sparrow.yaml
           {{- if .Values.extraArgs }}
           {{- range $key, $value := .Values.extraArgs }}
             - --{{ $key }}
@@ -63,30 +59,13 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- end }}
-          {{- if or .Values.runtimeConfig .Values.startupConfig}}
           volumeMounts:
-          {{- end }}
-          {{- if .Values.startupConfig}}
-            - name: startup
-              mountPath: /startupconfig
-          {{- end }}
-          {{- if .Values.runtimeConfig}}
-            - name: runtime
-              mountPath: /runconfig
-          {{- end }}
-      {{- if or .Values.runtimeConfig .Values.startupConfig}}
+            - name: config
+              mountPath: /config
       volumes:
-      {{- end }}
-      {{- if .Values.startupConfig}}
-        - name: startup
-          secret:
-            secretName: {{ include "sparrow.fullname" . }}
-      {{- end }}
-      {{- if .Values.runtimeConfig}}
-        - name: runtime
+        - name: config
           configMap:
             name: {{ include "sparrow.fullname" . }}
-      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/chart/templates/secret.yaml
+++ b/chart/templates/secret.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.startupConfig }}
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -7,7 +6,4 @@ metadata:
   labels:
     {{- include "sparrow.labels" . | nindent 4 }}
 data:
-  {{- if .Values.startupConfig}}
-  .sparrow.yaml: {{ toYaml .Values.startupConfig | b64enc }}
-  {{- end }}
-{{- end }}
+  .sparrow.yaml: {{ toYaml .Values.config | b64enc }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -93,13 +93,11 @@ affinity: {}
 
 # -- extra command line start parameters
 # see: https://github.com/caas-team/sparrow/blob/main/docs/sparrow_run.md
-extraArgs:
-  loaderFilePath: /runconfig/checks.yaml
-  loaderType: file
+extraArgs: {}
 
 # -- startup configuration of the Sparrow
 # see: https://github.com/caas-team/sparrow/blob/main/docs/sparrow_run.md
-startupConfig: {}
+config: {}
 # name: the-sparrow.com
 # api:
 #   address:
@@ -122,28 +120,24 @@ startupConfig: {}
 #     token: ""
 #     baseUrl: https://gitlab.com
 #     projectId: ""
-
-# -- runtime configuration of the Sparrow
-# see: https://github.com/caas-team/sparrow#runtime
-runtimeConfig: {}
-  # health:
-  #   interval: 20s
-  #   timeout: 10s
-  #   retry:
-  #     count: 3
-  #     delay: 1s
-  #   targets:
-  #     - "https://www.example.com/"
-  #     - "https://www.google.com/"
-  # latency:
-  #   interval: 1s
-  #   timeout: 3s
-  #   retry:
-  #     count: 3
-  #     delay: 1s
-  #   targets:
-  #     - https://example.com/
-  #     - https://google.com/
+# health:
+#   interval: 20s
+#   timeout: 10s
+#   retry:
+#     count: 3
+#     delay: 1s
+#   targets:
+#     - "https://www.example.com/"
+#     - "https://www.google.com/"
+# latency:
+#   interval: 1s
+#   timeout: 3s
+#   retry:
+#     count: 3
+#     delay: 1s
+#   targets:
+#     - https://example.com/
+#     - https://google.com/
 
 # -- Configure a service monitor for prometheus-operator
 serviceMonitor:


### PR DESCRIPTION
## Motivation

Simplifies the helm chart by removing the separate startup and runtime configs in favour of having a singular sparrow config file.
## Changes

- Merges runtimeConfig and startupConfig into a single object which gets deployed and mounted as a single configmap
- updated github actions to work with new chart

For additional information look at the commits.

## Tests done
- deployed locally
## TODO

- [ ] I've assigned this PR to myself
- [ ] I've labeled this PR correctly

<!-- Add open ToDo's to this checklist -->