### PR TITLE
fix/nil-runtime-cfg

### DIFF
--- a/internal/helper/retry.go
+++ b/internal/helper/retry.go
@@ -32,7 +32,7 @@ type RetryConfig struct {
 	Delay time.Duration `yaml:"delay"`
 }
 
-// Effector will be the function that is called by the Retry function
+// Effector will be the function called by the Retry function
 type Effector func(context.Context) error
 
 // Retry will retry the run the effector function in an exponential backoff

--- a/pkg/config/file.go
+++ b/pkg/config/file.go
@@ -33,6 +33,7 @@ var _ Loader = (*FileLoader)(nil)
 type FileLoader struct {
 	path string
 	c    chan<- map[string]any
+	done chan struct{}
 }
 
 func NewFileLoader(cfg *Config, cCfgChecks chan<- map[string]any) *FileLoader {
@@ -61,4 +62,13 @@ func (f *FileLoader) Run(ctx context.Context) error {
 
 	f.c <- cfg.Checks
 	return nil
+}
+
+func (f *FileLoader) Shutdown(ctx context.Context) {
+	log := logger.FromContext(ctx)
+	select {
+	case f.done <- struct{}{}:
+		log.Debug("Sending signal to shut down file loader")
+	default:
+	}
 }

--- a/pkg/config/file.go
+++ b/pkg/config/file.go
@@ -65,6 +65,8 @@ func (f *FileLoader) Run(ctx context.Context) error {
 }
 
 func (f *FileLoader) Shutdown(ctx context.Context) {
+	// proper implementation must still be done
+	// https://github.com/caas-team/sparrow/issues/85
 	log := logger.FromContext(ctx)
 	select {
 	case f.done <- struct{}{}:

--- a/pkg/config/http.go
+++ b/pkg/config/http.go
@@ -91,7 +91,6 @@ func (hl *HttpLoader) Run(ctx context.Context) error {
 // GetRuntimeConfig gets the remote runtime configuration
 func (hl *HttpLoader) GetRuntimeConfig(ctx context.Context) (*RuntimeConfig, error) {
 	log := logger.FromContext(ctx).With("url", hl.cfg.Loader.Http.Url)
-
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, hl.cfg.Loader.Http.Url, http.NoBody)
 	if err != nil {
 		log.Error("Could not create http GET request", "error", err.Error())

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -23,7 +23,14 @@ import (
 )
 
 type Loader interface {
+	// Run starts the loader routine.
+	// The loader should be able
+	// to handle all errors by itself and retry if necessary.
+	// If the context is canceled,
+	// the Run method returns an error.
 	Run(context.Context) error
+	// Shutdown stops the loader routine.
+	Shutdown(context.Context)
 }
 
 // NewLoader Get a new typed runtime configuration loader

--- a/pkg/config/runtime_config.go
+++ b/pkg/config/runtime_config.go
@@ -19,5 +19,5 @@
 package config
 
 type RuntimeConfig struct {
-	Checks map[string]any `yaml:"checks"`
+	Checks map[string]any `yaml:"checks" json:"checks"`
 }

--- a/pkg/sparrow/run.go
+++ b/pkg/sparrow/run.go
@@ -322,6 +322,7 @@ func (s *Sparrow) shutdown(ctx context.Context) {
 			errS = s.tarMan.Shutdown(ctx)
 		}
 		errA := s.shutdownAPI(ctx)
+		s.loader.Shutdown(ctx)
 		if errS != nil || errA != nil {
 			log.Error("Failed to shutdown gracefully", "contextError", errC, "apiError", errA, "targetError", errS)
 		}


### PR DESCRIPTION
## Motivation

- Closes https://github.com/caas-team/sparrow/issues/84
- Closes https://github.com/caas-team/sparrow/issues/71

## Changes

Added the `continue` mentioned in the issue.

To properly test the new changes I had to implement the Shutdown function for the loader, to properly shutdown the loader and not just let the `Run` goroutine end alone.


## Tests done

- New unit tests
- A manual E2E test where I couldn't load the remote RuntimeConfig from Gitlab was also sucessfull -> no panics.

## TODO

- [x] I've assigned this PR to myself
- [x] I've labeled this PR correctly

<!-- Add open ToDo's to this checklist -->