### PR TITLE
feat: added new workflow to prune old images

### DIFF
--- a/.github/workflows/prune.yml
+++ b/.github/workflows/prune.yml
@@ -48,8 +48,6 @@ jobs:
           keep-younger-than: 7 # days
           keep-last: 2
           prune-untagged: true
-          keep-tags: |
-            0.0.1
-            0.0.2
-            0.0.3
-            0.0.4
+          prune-tags-regexes: |
+            ^0.2.2-commit
+            ^0.3.0-commit

--- a/.github/workflows/prune.yml
+++ b/.github/workflows/prune.yml
@@ -29,7 +29,6 @@ jobs:
           container: sparrow # Package name
           dry-run: true # Dry-run first, then change to `false` or remove
           keep-younger-than: 7 # days
-          keep-last: 2
           prune-untagged: true
           prune-tags-regexes: |
             ^commit-
@@ -43,7 +42,6 @@ jobs:
           container: charts/sparrow # Package name
           dry-run: true # Dry-run first, then change to `false` or remove
           keep-younger-than: 7 # days
-          keep-last: 2
           prune-untagged: true
           prune-tags-regexes: |
             commit-.*$

--- a/.github/workflows/prune.yml
+++ b/.github/workflows/prune.yml
@@ -49,4 +49,4 @@ jobs:
           keep-last: 2
           prune-untagged: true
           prune-tags-regexes: |
-            'commit-*$'
+            '(?<=:\s*).*\bcommit\b.*'

--- a/.github/workflows/prune.yml
+++ b/.github/workflows/prune.yml
@@ -11,7 +11,14 @@ permissions:
 
 jobs:
   prune_images:
-  
+    name: Prune old sparrow images
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      packages: write
+      security-events: write
+
     steps:
     
       - name: Prune Images

--- a/.github/workflows/prune.yml
+++ b/.github/workflows/prune.yml
@@ -48,5 +48,8 @@ jobs:
           keep-younger-than: 7 # days
           keep-last: 2
           prune-untagged: true
-          prune-tags-regexes: |
-            commit
+          keep-tags: |
+            0.0.1
+            0.0.2
+            0.0.3
+            0.0.4

--- a/.github/workflows/prune.yml
+++ b/.github/workflows/prune.yml
@@ -49,4 +49,4 @@ jobs:
           keep-last: 2
           prune-untagged: true
           prune-tags-regexes: |
-            .-commit-.
+            ^.-commit

--- a/.github/workflows/prune.yml
+++ b/.github/workflows/prune.yml
@@ -2,7 +2,7 @@ name: Prune GHCR
 
 on:
   schedule:
-    - cron: '0 0 * * *' # Runs workflow at '(minute) (hour) (day of the month) (month) (day of the week)'
+    - cron: '0 0 * * *'
 
 permissions:
   contents: write
@@ -26,8 +26,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           organization: caas-team
-          container: sparrow # Package name
-          dry-run: true # Dry-run first, then change to `false` or remove
+          container: sparrow
+          dry-run: true
           keep-younger-than: 7 # days
           prune-untagged: true
           prune-tags-regexes: |
@@ -39,8 +39,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           organization: caas-team
-          container: charts/sparrow # Package name
-          dry-run: true # Dry-run first, then change to `false` or remove
+          container: charts/sparrow
+          dry-run: true
           keep-younger-than: 7 # days
           prune-untagged: true
           prune-tags-regexes: |

--- a/.github/workflows/prune.yml
+++ b/.github/workflows/prune.yml
@@ -49,5 +49,4 @@ jobs:
           keep-last: 2
           prune-untagged: true
           prune-tags-regexes: |
-            ^0.2.2-commit
-            ^0.3.0-commit
+            .-commit-.

--- a/.github/workflows/prune.yml
+++ b/.github/workflows/prune.yml
@@ -1,8 +1,8 @@
 name: Prune GHCR
 
 on:
-  push:
-  pull_request:
+  schedule:
+    - cron: '0 0 * * *' # Runs workflow at '(minute) (hour) (day of the month) (month) (day of the week)'
 
 permissions:
   contents: write
@@ -27,14 +27,13 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           organization: caas-team
           container: sparrow # Package name
-          dry-run: true # Dry-run first, then change to `false`
+          dry-run: true # Dry-run first, then change to `false` or remove
           keep-younger-than: 7 # days
           keep-last: 2
           prune-untagged: true
           prune-tags-regexes: |
             ^commit-
             SNAPSHOT-.*$
-            actions$
 
       - name: Prune Charts
         uses: vlaurin/action-ghcr-prune@v0.5.0
@@ -42,8 +41,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           organization: caas-team
           container: charts/sparrow # Package name
-          dry-run: true # Dry-run first, then change to `false`
-          #keep-younger-than: 7 # days
+          dry-run: true # Dry-run first, then change to `false` or remove
+          keep-younger-than: 7 # days
           keep-last: 2
           prune-untagged: true
           prune-tags-regexes: |

--- a/.github/workflows/prune.yml
+++ b/.github/workflows/prune.yml
@@ -49,4 +49,4 @@ jobs:
           keep-last: 2
           prune-untagged: true
           prune-tags-regexes: |
-            '(?<=:\s*).*\bcommit\b.*'
+            commit

--- a/.github/workflows/prune.yml
+++ b/.github/workflows/prune.yml
@@ -45,7 +45,7 @@ jobs:
           organization: caas-team
           container: charts/sparrow # Package name
           dry-run: true # Dry-run first, then change to `false`
-          keep-younger-than: 7 # days
+          #keep-younger-than: 7 # days
           keep-last: 2
           prune-untagged: true
           prune-tags-regexes: |

--- a/.github/workflows/prune.yml
+++ b/.github/workflows/prune.yml
@@ -49,4 +49,4 @@ jobs:
           keep-last: 2
           prune-untagged: true
           prune-tags-regexes: |
-            ^.-commit
+            commit-.*$

--- a/.github/workflows/prune.yml
+++ b/.github/workflows/prune.yml
@@ -14,11 +14,6 @@ jobs:
     name: Prune old sparrow images
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: write
-      packages: write
-      security-events: write
-
     steps:
     
       - name: Prune Images

--- a/.github/workflows/prune.yml
+++ b/.github/workflows/prune.yml
@@ -1,0 +1,45 @@
+name: Prune GHCR
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: write
+  packages: write
+  security-events: write
+
+jobs:
+  prune_images:
+  
+    steps:
+    
+      - name: Prune Images
+        uses: vlaurin/action-ghcr-prune@v0.5.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          organization: caas-team
+          container: sparrow # Package name
+          dry-run: true # Dry-run first, then change to `false`
+          keep-younger-than: 7 # days
+          keep-last: 2
+          prune-untagged: true
+          keep-tags: |
+            latest
+          keep-tags-regexes: |
+            ^v
+          prune-tags-regexes: |
+            ^commit-
+
+      - name: Prune Charts
+        uses: vlaurin/action-ghcr-prune@v0.5.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          organization: caas-team
+          container: charts/sparrow # Package name
+          dry-run: true # Dry-run first, then change to `false`
+          keep-younger-than: 7 # days
+          keep-last: 2
+          prune-untagged: true
+          prune-tags-regexes: |
+            'commit-*$'

--- a/.github/workflows/prune.yml
+++ b/.github/workflows/prune.yml
@@ -22,7 +22,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           organization: caas-team
           container: sparrow
-          dry-run: true
           keep-younger-than: 7 # days
           prune-untagged: true
           prune-tags-regexes: |
@@ -35,7 +34,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           organization: caas-team
           container: charts/sparrow
-          dry-run: true
           keep-younger-than: 7 # days
           prune-untagged: true
           prune-tags-regexes: |

--- a/.github/workflows/prune.yml
+++ b/.github/workflows/prune.yml
@@ -31,12 +31,10 @@ jobs:
           keep-younger-than: 7 # days
           keep-last: 2
           prune-untagged: true
-          keep-tags: |
-            latest
-          keep-tags-regexes: |
-            ^v
           prune-tags-regexes: |
             ^commit-
+            SNAPSHOT-.*$
+            actions$
 
       - name: Prune Charts
         uses: vlaurin/action-ghcr-prune@v0.5.0


### PR DESCRIPTION
## Motivation

<!-- Explain what motivated you to do these changes -->
Relates to https://github.com/caas-team/sparrow/issues/80
## Changes
Added a new workflow to prune old images of packages sparrow and charts/sparrow.

The workflow is configured to prune all images older than 7 days that start with 'commit-' or end in 'SNAPSHOT-...' for the sparrow package. 

For the charts/sparrow package it will prune all images older than 7 days that end in 'commit-...'.

It runs daily at midnight (could be changed if wanted).

It is still configured to dry-run just to be sure. This should be changed once we're sure nothings going to break.
<!-- Explain what you've changed -->

For additional information look at the commits.

## Tests done
I've tested the workflow in dry-run in a fork I made and it worked accordingly.

No stable version or version under 7 days was marked for pruning.

https://github.com/JTaeuber/sparrow/actions/runs/7642146860
This is the Test of the Workflow without keeping the images younger than 7 days for the charts/sparrow package, so you can see what it would prune if they were older than 7 days.
<!-- Explain what tests you've done and if your tests worked -->

## TODO

- [x] I've assigned this PR to myself
- [x] I've labeled this PR correctly

<!-- Add open ToDo's to this checklist -->