### PR TITLE
feat/registration-update

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,29 +21,18 @@ package config
 import (
 	"time"
 
+	"github.com/caas-team/sparrow/pkg/sparrow/targets"
+
 	"github.com/caas-team/sparrow/internal/helper"
 	"github.com/caas-team/sparrow/pkg/api"
 )
 
-type GitlabTargetManagerConfig struct {
-	BaseURL   string `yaml:"baseUrl" mapstructure:"baseUrl"`
-	Token     string `yaml:"token" mapstructure:"token"`
-	ProjectID int    `yaml:"projectId" mapstructure:"projectId"`
-}
-
-type TargetManagerConfig struct {
-	CheckInterval        time.Duration             `yaml:"checkInterval" mapstructure:"checkInterval"`
-	RegistrationInterval time.Duration             `yaml:"registrationInterval" mapstructure:"registrationInterval"`
-	UnhealthyThreshold   time.Duration             `yaml:"unhealthyThreshold" mapstructure:"unhealthyThreshold"`
-	Gitlab               GitlabTargetManagerConfig `yaml:"gitlab" mapstructure:"gitlab"`
-}
-
 type Config struct {
 	// SparrowName is the DNS name of the sparrow
-	SparrowName   string              `yaml:"name" mapstructure:"name"`
-	Loader        LoaderConfig        `yaml:"loader" mapstructure:"loader"`
-	Api           api.Config          `yaml:"api" mapstructure:"api"`
-	TargetManager TargetManagerConfig `yaml:"targetManager" mapstructure:"targetManager"`
+	SparrowName   string                      `yaml:"name" mapstructure:"name"`
+	Loader        LoaderConfig                `yaml:"loader" mapstructure:"loader"`
+	Api           api.Config                  `yaml:"api" mapstructure:"api"`
+	TargetManager targets.TargetManagerConfig `yaml:"targetManager" mapstructure:"targetManager"`
 }
 
 // LoaderConfig is the configuration for loader
@@ -69,5 +58,5 @@ type FileLoaderConfig struct {
 
 // HasTargetManager returns true if the config has a target manager
 func (c *Config) HasTargetManager() bool {
-	return c.TargetManager != TargetManagerConfig{}
+	return c.TargetManager != targets.TargetManagerConfig{}
 }

--- a/pkg/sparrow/run_test.go
+++ b/pkg/sparrow/run_test.go
@@ -196,9 +196,11 @@ func TestSparrow_Run_FullComponentStart(t *testing.T) {
 			Interval: time.Second * 1,
 		},
 		TargetManager: targets.TargetManagerConfig{
-			CheckInterval:        time.Second * 1,
-			RegistrationInterval: time.Second * 1,
-			UnhealthyThreshold:   time.Second * 1,
+			Config: targets.Config{
+				CheckInterval:        time.Second * 1,
+				RegistrationInterval: time.Second * 1,
+				UnhealthyThreshold:   time.Second * 1,
+			},
 			Gitlab: targets.GitlabTargetManagerConfig{
 				BaseURL:   "https://gitlab.com",
 				Token:     "my-cool-token",

--- a/pkg/sparrow/run_test.go
+++ b/pkg/sparrow/run_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/caas-team/sparrow/pkg/sparrow/targets"
+
 	"github.com/caas-team/sparrow/pkg/api"
 	"github.com/caas-team/sparrow/pkg/checks/dns"
 
@@ -193,11 +195,11 @@ func TestSparrow_Run_FullComponentStart(t *testing.T) {
 			File:     config.FileLoaderConfig{Path: "../config/testdata/config.yaml"},
 			Interval: time.Second * 1,
 		},
-		TargetManager: config.TargetManagerConfig{
+		TargetManager: targets.TargetManagerConfig{
 			CheckInterval:        time.Second * 1,
 			RegistrationInterval: time.Second * 1,
 			UnhealthyThreshold:   time.Second * 1,
-			Gitlab: config.GitlabTargetManagerConfig{
+			Gitlab: targets.GitlabTargetManagerConfig{
 				BaseURL:   "https://gitlab.com",
 				Token:     "my-cool-token",
 				ProjectID: 42,

--- a/pkg/sparrow/targets/errors.go
+++ b/pkg/sparrow/targets/errors.go
@@ -1,3 +1,21 @@
+// sparrow
+// (C) 2023, Deutsche Telekom IT GmbH
+//
+// Deutsche Telekom IT GmbH and all other contributors /
+// copyright owners license this file to you under the Apache
+// License, Version 2.0 (the "License"); you may not use this
+// file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package targets
 
 import "errors"

--- a/pkg/sparrow/targets/errors.go
+++ b/pkg/sparrow/targets/errors.go
@@ -1,0 +1,12 @@
+package targets
+
+import "errors"
+
+// ErrInvalidCheckInterval is returned when the check interval is invalid
+var ErrInvalidCheckInterval = errors.New("invalid check interval")
+
+// ErrInvalidRegistrationInterval is returned when the registration interval is invalid
+var ErrInvalidRegistrationInterval = errors.New("invalid registration interval")
+
+// ErrInvalidUnhealthyThreshold is returned when the unhealthy threshold is invalid
+var ErrInvalidUnhealthyThreshold = errors.New("invalid unhealthy threshold")

--- a/pkg/sparrow/targets/gitlab.go
+++ b/pkg/sparrow/targets/gitlab.go
@@ -43,31 +43,40 @@ type gitlabTargetManager struct {
 	targets []checks.GlobalTarget
 	mu      sync.RWMutex
 	// channel to signal the "reconcile" routine to stop
-	done   chan struct{}
-	gitlab gitlab.Gitlab
+	done chan struct{}
 	// the DNS name used for self-registration
 	name string
-	// the interval for the target reconciliation process
-	checkInterval time.Duration
-	// the amount of time a target can be
-	// unhealthy before it is removed from the global target list
-	unhealthyThreshold time.Duration
-	// how often the instance should register itself as a global target
-	registrationInterval time.Duration
 	// whether the instance has already registered itself as a global target
 	registered bool
+	cfg        cfg
+	gitlab     gitlab.Gitlab
+}
+
+// cfg contains the configuration for the gitlabTargetManager
+type cfg struct {
+	// The interval for the target reconciliation process
+	checkInterval time.Duration
+	// The amount of time a target can be unhealthy
+	// before it is removed from the global target list.
+	// A duration of 0 means no removal.
+	unhealthyThreshold time.Duration
+	// How often the instance should register itself as a global target.
+	// A duration of 0 means no registration.
+	registrationInterval time.Duration
 }
 
 // NewGitlabManager creates a new gitlabTargetManager
 func NewGitlabManager(name string, gtmConfig config.TargetManagerConfig) *gitlabTargetManager {
 	return &gitlabTargetManager{
-		gitlab:               gitlab.New(gtmConfig.Gitlab.BaseURL, gtmConfig.Gitlab.Token, gtmConfig.Gitlab.ProjectID),
-		name:                 name,
-		checkInterval:        gtmConfig.CheckInterval,
-		registrationInterval: gtmConfig.RegistrationInterval,
-		unhealthyThreshold:   gtmConfig.UnhealthyThreshold,
-		mu:                   sync.RWMutex{},
-		done:                 make(chan struct{}, 1),
+		gitlab: gitlab.New(gtmConfig.Gitlab.BaseURL, gtmConfig.Gitlab.Token, gtmConfig.Gitlab.ProjectID),
+		name:   name,
+		cfg: cfg{
+			checkInterval:        gtmConfig.CheckInterval,
+			registrationInterval: gtmConfig.RegistrationInterval,
+			unhealthyThreshold:   gtmConfig.UnhealthyThreshold,
+		},
+		mu:   sync.RWMutex{},
+		done: make(chan struct{}, 1),
 	}
 }
 
@@ -80,8 +89,8 @@ func (t *gitlabTargetManager) Reconcile(ctx context.Context) error {
 	log := logger.FromContext(ctx)
 	log.Info("Starting global gitlabTargetManager reconciler")
 
-	checkTimer := time.NewTimer(t.checkInterval)
-	registrationTimer := time.NewTimer(t.registrationInterval)
+	checkTimer := time.NewTimer(t.cfg.checkInterval)
+	registrationTimer := time.NewTimer(t.cfg.registrationInterval)
 
 	defer checkTimer.Stop()
 	defer registrationTimer.Stop()
@@ -99,13 +108,13 @@ func (t *gitlabTargetManager) Reconcile(ctx context.Context) error {
 			if err != nil {
 				log.Warn("Failed to get global targets", "error", err)
 			}
-			checkTimer.Reset(t.checkInterval)
+			checkTimer.Reset(t.cfg.checkInterval)
 		case <-registrationTimer.C:
 			err := t.updateRegistration(ctx)
 			if err != nil {
 				log.Warn("Failed to register self as global target", "error", err)
 			}
-			registrationTimer.Reset(t.registrationInterval)
+			registrationTimer.Reset(t.cfg.registrationInterval)
 		}
 	}
 }
@@ -211,7 +220,7 @@ func (t *gitlabTargetManager) refreshTargets(ctx context.Context) error {
 			log.Debug("Found self as global target", "lastSeenMin", time.Since(target.LastSeen).Minutes())
 			t.registered = true
 		}
-		if time.Now().Add(-t.unhealthyThreshold).After(target.LastSeen) {
+		if time.Now().Add(-t.cfg.unhealthyThreshold).After(target.LastSeen) {
 			log.Debug("Skipping unhealthy target", "target", target)
 			continue
 		}

--- a/pkg/sparrow/targets/gitlab.go
+++ b/pkg/sparrow/targets/gitlab.go
@@ -27,8 +27,6 @@ import (
 
 	"github.com/caas-team/sparrow/pkg/checks"
 
-	"github.com/caas-team/sparrow/pkg/config"
-
 	"github.com/caas-team/sparrow/pkg/sparrow/gitlab"
 
 	"github.com/caas-team/sparrow/internal/logger"
@@ -52,6 +50,12 @@ type gitlabTargetManager struct {
 	gitlab     gitlab.Gitlab
 }
 
+type GitlabTargetManagerConfig struct {
+	BaseURL   string `yaml:"baseUrl" mapstructure:"baseUrl"`
+	Token     string `yaml:"token" mapstructure:"token"`
+	ProjectID int    `yaml:"projectId" mapstructure:"projectId"`
+}
+
 // cfg contains the configuration for the gitlabTargetManager
 type cfg struct {
 	// The interval for the target reconciliation process
@@ -66,7 +70,7 @@ type cfg struct {
 }
 
 // NewGitlabManager creates a new gitlabTargetManager
-func NewGitlabManager(name string, gtmConfig config.TargetManagerConfig) *gitlabTargetManager {
+func NewGitlabManager(name string, gtmConfig TargetManagerConfig) *gitlabTargetManager {
 	return &gitlabTargetManager{
 		gitlab: gitlab.New(gtmConfig.Gitlab.BaseURL, gtmConfig.Gitlab.Token, gtmConfig.Gitlab.ProjectID),
 		name:   name,

--- a/pkg/sparrow/targets/gitlab_test.go
+++ b/pkg/sparrow/targets/gitlab_test.go
@@ -110,7 +110,7 @@ func Test_gitlabTargetManager_refreshTargets(t *testing.T) {
 				targets: nil,
 				gitlab:  gitlab,
 				name:    "test",
-				cfg:     cfg{unhealthyThreshold: time.Hour},
+				cfg:     Config{UnhealthyThreshold: time.Hour},
 			}
 			if err := gtm.refreshTargets(context.Background()); (err != nil) != (tt.wantErr != nil) {
 				t.Fatalf("refreshTargets() error = %v, wantErr %v", err, tt.wantErr)
@@ -514,10 +514,10 @@ func mockGitlabTargetManager(g *gitlabmock.MockClient, name string) *gitlabTarge
 		done:    make(chan struct{}, 1),
 		gitlab:  g,
 		name:    name,
-		cfg: cfg{
-			checkInterval:        100 * time.Millisecond,
-			unhealthyThreshold:   1 * time.Second,
-			registrationInterval: 150 * time.Millisecond,
+		cfg: Config{
+			CheckInterval:        100 * time.Millisecond,
+			UnhealthyThreshold:   1 * time.Second,
+			RegistrationInterval: 150 * time.Millisecond,
 		},
 		registered: false,
 	}

--- a/pkg/sparrow/targets/gitlab_test.go
+++ b/pkg/sparrow/targets/gitlab_test.go
@@ -107,10 +107,10 @@ func Test_gitlabTargetManager_refreshTargets(t *testing.T) {
 				gitlab.SetFetchFilesErr(tt.wantErr)
 			}
 			gtm := &gitlabTargetManager{
-				targets:            nil,
-				gitlab:             gitlab,
-				name:               "test",
-				unhealthyThreshold: time.Hour,
+				targets: nil,
+				gitlab:  gitlab,
+				name:    "test",
+				cfg:     cfg{unhealthyThreshold: time.Hour},
 			}
 			if err := gtm.refreshTargets(context.Background()); (err != nil) != (tt.wantErr != nil) {
 				t.Fatalf("refreshTargets() error = %v, wantErr %v", err, tt.wantErr)
@@ -509,14 +509,16 @@ func Test_gitlabTargetManager_Reconcile_Shutdown_Fail_Unregister(t *testing.T) {
 
 func mockGitlabTargetManager(g *gitlabmock.MockClient, name string) *gitlabTargetManager { //nolint: unparam // irrelevant
 	return &gitlabTargetManager{
-		targets:              nil,
-		mu:                   sync.RWMutex{},
-		done:                 make(chan struct{}, 1),
-		gitlab:               g,
-		name:                 name,
-		checkInterval:        100 * time.Millisecond,
-		unhealthyThreshold:   1 * time.Second,
-		registrationInterval: 150 * time.Millisecond,
-		registered:           false,
+		targets: nil,
+		mu:      sync.RWMutex{},
+		done:    make(chan struct{}, 1),
+		gitlab:  g,
+		name:    name,
+		cfg: cfg{
+			checkInterval:        100 * time.Millisecond,
+			unhealthyThreshold:   1 * time.Second,
+			registrationInterval: 150 * time.Millisecond,
+		},
+		registered: false,
 	}
 }

--- a/pkg/sparrow/targets/targetmanager.go
+++ b/pkg/sparrow/targets/targetmanager.go
@@ -56,7 +56,7 @@ type TargetManagerConfig struct {
 	Gitlab GitlabTargetManagerConfig `yaml:"gitlab" mapstructure:"gitlab"`
 }
 
-func (tmc *TargetManagerConfig) Validate() error {
+func (tmc *Config) Validate() error {
 	if tmc.CheckInterval <= 0 {
 		return ErrInvalidCheckInterval
 	}

--- a/pkg/sparrow/targets/targetmanager.go
+++ b/pkg/sparrow/targets/targetmanager.go
@@ -20,6 +20,7 @@ package targets
 
 import (
 	"context"
+	"time"
 
 	"github.com/caas-team/sparrow/pkg/checks"
 )
@@ -35,4 +36,24 @@ type TargetManager interface {
 	// Shutdown shuts down the target manager
 	// and unregisters the instance as a global target
 	Shutdown(ctx context.Context) error
+}
+
+type TargetManagerConfig struct {
+	CheckInterval        time.Duration             `yaml:"checkInterval" mapstructure:"checkInterval"`
+	RegistrationInterval time.Duration             `yaml:"registrationInterval" mapstructure:"registrationInterval"`
+	UnhealthyThreshold   time.Duration             `yaml:"unhealthyThreshold" mapstructure:"unhealthyThreshold"`
+	Gitlab               GitlabTargetManagerConfig `yaml:"gitlab" mapstructure:"gitlab"`
+}
+
+func (tmc *TargetManagerConfig) Validate() error {
+	if tmc.CheckInterval <= 0 {
+		return ErrInvalidCheckInterval
+	}
+	if tmc.RegistrationInterval < 0 {
+		return ErrInvalidRegistrationInterval
+	}
+	if tmc.UnhealthyThreshold < 0 {
+		return ErrInvalidUnhealthyThreshold
+	}
+	return nil
 }

--- a/pkg/sparrow/targets/targetmanager.go
+++ b/pkg/sparrow/targets/targetmanager.go
@@ -38,11 +38,22 @@ type TargetManager interface {
 	Shutdown(ctx context.Context) error
 }
 
+// Config is the general configuration of the target manager
+type Config struct {
+	// The interval for the target reconciliation process
+	CheckInterval time.Duration `yaml:"checkInterval" mapstructure:"checkInterval"`
+	// How often the instance should register itself as a global target.
+	// A duration of 0 means no registration.
+	RegistrationInterval time.Duration `yaml:"registrationInterval" mapstructure:"registrationInterval"`
+	// The amount of time a target can be unhealthy
+	// before it is removed from the global target list.
+	// A duration of 0 means no removal.
+	UnhealthyThreshold time.Duration `yaml:"unhealthyThreshold" mapstructure:"unhealthyThreshold"`
+}
+
 type TargetManagerConfig struct {
-	CheckInterval        time.Duration             `yaml:"checkInterval" mapstructure:"checkInterval"`
-	RegistrationInterval time.Duration             `yaml:"registrationInterval" mapstructure:"registrationInterval"`
-	UnhealthyThreshold   time.Duration             `yaml:"unhealthyThreshold" mapstructure:"unhealthyThreshold"`
-	Gitlab               GitlabTargetManagerConfig `yaml:"gitlab" mapstructure:"gitlab"`
+	Config
+	Gitlab GitlabTargetManagerConfig `yaml:"gitlab" mapstructure:"gitlab"`
 }
 
 func (tmc *TargetManagerConfig) Validate() error {

--- a/pkg/sparrow/targets/targetmanager_test.go
+++ b/pkg/sparrow/targets/targetmanager_test.go
@@ -1,0 +1,60 @@
+package targets
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTargetManagerConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     TargetManagerConfig
+		wantErr bool
+	}{
+		{
+			name:    "empty config",
+			wantErr: true,
+		},
+		{
+			name: "valid config - non-zero values",
+			cfg: TargetManagerConfig{
+				UnhealthyThreshold:   1 * time.Second,
+				CheckInterval:        1 * time.Second,
+				RegistrationInterval: 1 * time.Second,
+			},
+		},
+		{
+			name: "valid config - zero values",
+			cfg: TargetManagerConfig{
+				UnhealthyThreshold:   0,
+				CheckInterval:        1 * time.Second,
+				RegistrationInterval: 0,
+			},
+		},
+		{
+			name: "invalid config - zero check interval",
+			cfg: TargetManagerConfig{
+				UnhealthyThreshold:   1 * time.Second,
+				CheckInterval:        0,
+				RegistrationInterval: 1 * time.Second,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid config - negative values",
+			cfg: TargetManagerConfig{
+				UnhealthyThreshold:   -1 * time.Second,
+				CheckInterval:        1 * time.Second,
+				RegistrationInterval: 1 * time.Second,
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.cfg.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/sparrow/targets/targetmanager_test.go
+++ b/pkg/sparrow/targets/targetmanager_test.go
@@ -18,34 +18,42 @@ func TestTargetManagerConfig_Validate(t *testing.T) {
 		{
 			name: "valid config - non-zero values",
 			cfg: TargetManagerConfig{
-				UnhealthyThreshold:   1 * time.Second,
-				CheckInterval:        1 * time.Second,
-				RegistrationInterval: 1 * time.Second,
+				Config: Config{
+					UnhealthyThreshold:   1 * time.Second,
+					CheckInterval:        1 * time.Second,
+					RegistrationInterval: 1 * time.Second,
+				},
 			},
 		},
 		{
 			name: "valid config - zero values",
 			cfg: TargetManagerConfig{
-				UnhealthyThreshold:   0,
-				CheckInterval:        1 * time.Second,
-				RegistrationInterval: 0,
+				Config: Config{
+					UnhealthyThreshold:   0,
+					CheckInterval:        1 * time.Second,
+					RegistrationInterval: 0,
+				},
 			},
 		},
 		{
 			name: "invalid config - zero check interval",
 			cfg: TargetManagerConfig{
-				UnhealthyThreshold:   1 * time.Second,
-				CheckInterval:        0,
-				RegistrationInterval: 1 * time.Second,
+				Config: Config{
+					UnhealthyThreshold:   1 * time.Second,
+					CheckInterval:        0,
+					RegistrationInterval: 1 * time.Second,
+				},
 			},
 			wantErr: true,
 		},
 		{
 			name: "invalid config - negative values",
 			cfg: TargetManagerConfig{
-				UnhealthyThreshold:   -1 * time.Second,
-				CheckInterval:        1 * time.Second,
-				RegistrationInterval: 1 * time.Second,
+				Config: Config{
+					UnhealthyThreshold:   -1 * time.Second,
+					CheckInterval:        1 * time.Second,
+					RegistrationInterval: 1 * time.Second,
+				},
 			},
 			wantErr: true,
 		},

--- a/pkg/sparrow/targets/targetmanager_test.go
+++ b/pkg/sparrow/targets/targetmanager_test.go
@@ -1,3 +1,21 @@
+// sparrow
+// (C) 2023, Deutsche Telekom IT GmbH
+//
+// Deutsche Telekom IT GmbH and all other contributors /
+// copyright owners license this file to you under the Apache
+// License, Version 2.0 (the "License"); you may not use this
+// file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package targets
 
 import (

--- a/pkg/sparrow/targets/targetmanager_test.go
+++ b/pkg/sparrow/targets/targetmanager_test.go
@@ -8,7 +8,7 @@ import (
 func TestTargetManagerConfig_Validate(t *testing.T) {
 	tests := []struct {
 		name    string
-		cfg     TargetManagerConfig
+		cfg     Config
 		wantErr bool
 	}{
 		{
@@ -17,43 +17,35 @@ func TestTargetManagerConfig_Validate(t *testing.T) {
 		},
 		{
 			name: "valid config - non-zero values",
-			cfg: TargetManagerConfig{
-				Config: Config{
-					UnhealthyThreshold:   1 * time.Second,
-					CheckInterval:        1 * time.Second,
-					RegistrationInterval: 1 * time.Second,
-				},
+			cfg: Config{
+				UnhealthyThreshold:   1 * time.Second,
+				CheckInterval:        1 * time.Second,
+				RegistrationInterval: 1 * time.Second,
 			},
 		},
 		{
 			name: "valid config - zero values",
-			cfg: TargetManagerConfig{
-				Config: Config{
-					UnhealthyThreshold:   0,
-					CheckInterval:        1 * time.Second,
-					RegistrationInterval: 0,
-				},
+			cfg: Config{
+				UnhealthyThreshold:   0,
+				CheckInterval:        1 * time.Second,
+				RegistrationInterval: 0,
 			},
 		},
 		{
 			name: "invalid config - zero check interval",
-			cfg: TargetManagerConfig{
-				Config: Config{
-					UnhealthyThreshold:   1 * time.Second,
-					CheckInterval:        0,
-					RegistrationInterval: 1 * time.Second,
-				},
+			cfg: Config{
+				UnhealthyThreshold:   1 * time.Second,
+				CheckInterval:        0,
+				RegistrationInterval: 1 * time.Second,
 			},
 			wantErr: true,
 		},
 		{
 			name: "invalid config - negative values",
-			cfg: TargetManagerConfig{
-				Config: Config{
-					UnhealthyThreshold:   -1 * time.Second,
-					CheckInterval:        1 * time.Second,
-					RegistrationInterval: 1 * time.Second,
-				},
+			cfg: Config{
+				UnhealthyThreshold:   -1 * time.Second,
+				CheckInterval:        1 * time.Second,
+				RegistrationInterval: 1 * time.Second,
 			},
 			wantErr: true,
 		},


### PR DESCRIPTION
## Motivation

Part of https://github.com/caas-team/sparrow/issues/101

I'll split this into two PRs to keep them easy to merge. First comes the cleanup and refactoring needed and then comes the feature itself. 

## Changes

I've added a more general `Config` struct to the `targetManager`, which includes the general config each `targetManager` should have. This will also include a new field in a coming PR, to regulate the update interval.

I've added a simple Validation function for the general config, to prerpare for the new feature (0 duration will disable the update & registration). A zero checkInterval makes no sense, so it's not allowed.

The rest ist fixing tests and moving the configs to the `targets` package, as we've done with other PRs.

For additional information look at the commits.

## Tests done

- [x] New unittests

## Future plans

We can regulate the update & registration interval by using the magic number 0 (which is a possible value for the interval). Since the practice to use that number is common, we should adopt it, instead of just dropping the value as not-OK.

## TODO

- [x] I've assigned this PR to myself
- [x] I've labeled this PR correctly

<!-- Add open ToDo's to this checklist -->