### PR TITLE
feat: check config validation

### DIFF
--- a/.github/workflows/end2end.yml
+++ b/.github/workflows/end2end.yml
@@ -62,6 +62,7 @@ jobs:
           --set sparrowConfig.loader.interval=5s \
           --set sparrowConfig.loader.file.path=/config/.sparrow.yaml \
           --set checksConfig.health.interval=1s \
+          --set checksConfig.health.timeout=1s \
           ./chart
 
     - name: Check Pods

--- a/pkg/checks/base.go
+++ b/pkg/checks/base.go
@@ -77,6 +77,8 @@ type CheckBase struct {
 type Runtime interface {
 	// For returns the name of the check being configured
 	For() string
+	// Validate checks if the configuration is valid
+	Validate() error
 }
 
 // Result encapsulates the outcome of a check run.

--- a/pkg/checks/dns/config.go
+++ b/pkg/checks/dns/config.go
@@ -46,19 +46,19 @@ func (c *Config) For() string {
 }
 
 // Validate checks if the configuration is valid
-func (h *Config) Validate() error {
-	for _, t := range h.Targets {
+func (c *Config) Validate() error {
+	for _, t := range c.Targets {
 		if strings.HasPrefix(t, "https://") || strings.HasPrefix(t, "http://") {
-			return checks.ErrInvalidConfig{Field: "targets", Reason: "target URLs must not start with 'https://' or 'http://'"}
+			return checks.ErrInvalidConfig{CheckName: c.For(), Field: "targets", Reason: "target URLs must not start with 'https://' or 'http://'"}
 		}
 	}
 
-	if h.Interval < minInterval {
-		return checks.ErrInvalidConfig{Field: "interval", Reason: fmt.Sprintf("interval must be at least %v", minInterval)}
+	if c.Interval < minInterval {
+		return checks.ErrInvalidConfig{CheckName: c.For(), Field: "interval", Reason: fmt.Sprintf("interval must be at least %v", minInterval)}
 	}
 
-	if h.Timeout < minTimeout {
-		return checks.ErrInvalidConfig{Field: "timeout", Reason: fmt.Sprintf("timeout must be at least %v", minTimeout)}
+	if c.Timeout < minTimeout {
+		return checks.ErrInvalidConfig{CheckName: c.For(), Field: "timeout", Reason: fmt.Sprintf("timeout must be at least %v", minTimeout)}
 	}
 
 	return nil

--- a/pkg/checks/dns/config.go
+++ b/pkg/checks/dns/config.go
@@ -1,0 +1,61 @@
+// sparrow
+// (C) 2024, Deutsche Telekom IT GmbH
+//
+// Deutsche Telekom IT GmbH and all other contributors /
+// copyright owners license this file to you under the Apache
+// License, Version 2.0 (the "License"); you may not use this
+// file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dns
+
+import (
+	"time"
+
+	"github.com/caas-team/sparrow/internal/helper"
+	"github.com/caas-team/sparrow/pkg/checks"
+)
+
+const (
+	minInterval = 100 * time.Millisecond
+	minTimeout  = 1 * time.Second
+)
+
+// Config defines the configuration parameters for a DNS check
+type Config struct {
+	Targets  []string           `json:"targets" yaml:"targets"`
+	Interval time.Duration      `json:"interval" yaml:"interval"`
+	Timeout  time.Duration      `json:"timeout" yaml:"timeout"`
+	Retry    helper.RetryConfig `json:"retry" yaml:"retry"`
+}
+
+// For returns the name of the check
+func (c *Config) For() string {
+	return CheckName
+}
+
+// Validate checks if the configuration is valid
+func (h *Config) Validate() error {
+	if len(h.Targets) == 0 {
+		return checks.ErrInvalidConfig{Field: "targets", Reason: "no targets defined"}
+	}
+
+	if h.Interval < minInterval {
+		return checks.ErrInvalidConfig{Field: "interval", Reason: "interval must be at least 100ms"}
+	}
+
+	if h.Timeout < minTimeout {
+		return checks.ErrInvalidConfig{Field: "timeout", Reason: "timeout must be at least 1s"}
+	}
+
+	return nil
+}

--- a/pkg/checks/dns/config.go
+++ b/pkg/checks/dns/config.go
@@ -19,6 +19,8 @@
 package dns
 
 import (
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/caas-team/sparrow/internal/helper"
@@ -27,7 +29,7 @@ import (
 
 const (
 	minInterval = 100 * time.Millisecond
-	minTimeout  = 1 * time.Second
+	minTimeout  = 200 * time.Millisecond
 )
 
 // Config defines the configuration parameters for a DNS check
@@ -45,16 +47,18 @@ func (c *Config) For() string {
 
 // Validate checks if the configuration is valid
 func (h *Config) Validate() error {
-	if len(h.Targets) == 0 {
-		return checks.ErrInvalidConfig{Field: "targets", Reason: "no targets defined"}
+	for _, t := range h.Targets {
+		if strings.HasPrefix(t, "https://") || strings.HasPrefix(t, "http://") {
+			return checks.ErrInvalidConfig{Field: "targets", Reason: "target URLs must not start with 'https://' or 'http://'"}
+		}
 	}
 
 	if h.Interval < minInterval {
-		return checks.ErrInvalidConfig{Field: "interval", Reason: "interval must be at least 100ms"}
+		return checks.ErrInvalidConfig{Field: "interval", Reason: fmt.Sprintf("interval must be at least %v", minInterval)}
 	}
 
 	if h.Timeout < minTimeout {
-		return checks.ErrInvalidConfig{Field: "timeout", Reason: "timeout must be at least 1s"}
+		return checks.ErrInvalidConfig{Field: "timeout", Reason: fmt.Sprintf("timeout must be at least %v", minTimeout)}
 	}
 
 	return nil

--- a/pkg/checks/dns/config_test.go
+++ b/pkg/checks/dns/config_test.go
@@ -32,16 +32,25 @@ func TestConfig_Validate(t *testing.T) {
 		{
 			name: "valid config",
 			config: Config{
-				Targets:  []string{"http://localhost:8080"},
+				Targets:  []string{"example.com"},
 				Interval: 100 * time.Millisecond,
 				Timeout:  1 * time.Second,
 			},
 			wantErr: false,
 		},
 		{
+			name: "invalid targets",
+			config: Config{
+				Targets:  []string{"http://example.com", "https://google.com"},
+				Interval: 100 * time.Millisecond,
+				Timeout:  1 * time.Second,
+			},
+			wantErr: true,
+		},
+		{
 			name: "invalid interval",
 			config: Config{
-				Targets:  []string{"http://localhost:8080"},
+				Targets:  []string{"example.com"},
 				Interval: 10 * time.Millisecond,
 				Timeout:  1 * time.Second,
 			},
@@ -50,18 +59,9 @@ func TestConfig_Validate(t *testing.T) {
 		{
 			name: "invalid timeout",
 			config: Config{
-				Targets:  []string{"http://localhost:8080"},
+				Targets:  []string{"example.com"},
 				Interval: 100 * time.Millisecond,
 				Timeout:  100 * time.Millisecond,
-			},
-			wantErr: true,
-		},
-		{
-			name: "no targets",
-			config: Config{
-				Targets:  []string{},
-				Interval: 100 * time.Millisecond,
-				Timeout:  1 * time.Second,
 			},
 			wantErr: true,
 		},

--- a/pkg/checks/dns/config_test.go
+++ b/pkg/checks/dns/config_test.go
@@ -1,0 +1,78 @@
+// sparrow
+// (C) 2024, Deutsche Telekom IT GmbH
+//
+// Deutsche Telekom IT GmbH and all other contributors /
+// copyright owners license this file to you under the Apache
+// License, Version 2.0 (the "License"); you may not use this
+// file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dns
+
+import (
+	"testing"
+	"time"
+)
+
+func TestConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  Config
+		wantErr bool
+	}{
+		{
+			name: "valid config",
+			config: Config{
+				Targets:  []string{"http://localhost:8080"},
+				Interval: 100 * time.Millisecond,
+				Timeout:  1 * time.Second,
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid interval",
+			config: Config{
+				Targets:  []string{"http://localhost:8080"},
+				Interval: 10 * time.Millisecond,
+				Timeout:  1 * time.Second,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid timeout",
+			config: Config{
+				Targets:  []string{"http://localhost:8080"},
+				Interval: 100 * time.Millisecond,
+				Timeout:  100 * time.Millisecond,
+			},
+			wantErr: true,
+		},
+		{
+			name: "no targets",
+			config: Config{
+				Targets:  []string{},
+				Interval: 100 * time.Millisecond,
+				Timeout:  1 * time.Second,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Config.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/checks/dns/dns.go
+++ b/pkg/checks/dns/dns.go
@@ -72,18 +72,6 @@ func NewCheck() checks.Check {
 	}
 }
 
-// Config defines the configuration parameters for a DNS check
-type Config struct {
-	Targets  []string           `json:"targets" yaml:"targets"`
-	Interval time.Duration      `json:"interval" yaml:"interval"`
-	Timeout  time.Duration      `json:"timeout" yaml:"timeout"`
-	Retry    helper.RetryConfig `json:"retry" yaml:"retry"`
-}
-
-func (c Config) For() string {
-	return CheckName
-}
-
 // result represents the result of a single DNS check for a specific target
 type result struct {
 	Resolved []string

--- a/pkg/checks/errors.go
+++ b/pkg/checks/errors.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 )
 
+// ErrConfigMismatch is returned when a configuration is of the wrong type
 type ErrConfigMismatch struct {
 	Expected string
 	Current  string
@@ -29,4 +30,14 @@ type ErrConfigMismatch struct {
 
 func (e ErrConfigMismatch) Error() string {
 	return fmt.Sprintf("config mismatch: expected type %v, got %v", e.Expected, e.Current)
+}
+
+// ErrInvalidConfig is returned when a configuration is invalid
+type ErrInvalidConfig struct {
+	Field  string
+	Reason string
+}
+
+func (e ErrInvalidConfig) Error() string {
+	return fmt.Sprintf("invalid config field %v: %v", e.Field, e.Reason)
 }

--- a/pkg/checks/errors.go
+++ b/pkg/checks/errors.go
@@ -34,10 +34,11 @@ func (e ErrConfigMismatch) Error() string {
 
 // ErrInvalidConfig is returned when a configuration is invalid
 type ErrInvalidConfig struct {
-	Field  string
-	Reason string
+	CheckName string
+	Field     string
+	Reason    string
 }
 
 func (e ErrInvalidConfig) Error() string {
-	return fmt.Sprintf("invalid config field %v: %v", e.Field, e.Reason)
+	return fmt.Sprintf("invalid configuration field '%s' in check '%s': %s", e.Field, e.CheckName, e.Reason)
 }

--- a/pkg/checks/health/config.go
+++ b/pkg/checks/health/config.go
@@ -41,24 +41,24 @@ type Config struct {
 }
 
 // For returns the name of the check
-func (h *Config) For() string {
+func (c *Config) For() string {
 	return CheckName
 }
 
 // Validate checks if the configuration is valid
-func (h *Config) Validate() error {
-	for _, t := range h.Targets {
+func (c *Config) Validate() error {
+	for _, t := range c.Targets {
 		if !strings.HasPrefix(t, "https://") && !strings.HasPrefix(t, "http://") {
-			return checks.ErrInvalidConfig{Field: "targets", Reason: "target URLs must start with 'https://' or 'http://'"}
+			return checks.ErrInvalidConfig{CheckName: c.For(), Field: "targets", Reason: "target URLs must start with 'https://' or 'http://'"}
 		}
 	}
 
-	if h.Interval < minInterval {
-		return checks.ErrInvalidConfig{Field: "interval", Reason: fmt.Sprintf("interval must be at least %v", minInterval)}
+	if c.Interval < minInterval {
+		return checks.ErrInvalidConfig{CheckName: c.For(), Field: "interval", Reason: fmt.Sprintf("interval must be at least %v", minInterval)}
 	}
 
-	if h.Timeout < minTimeout {
-		return checks.ErrInvalidConfig{Field: "timeout", Reason: fmt.Sprintf("timeout must be at least %v", minTimeout)}
+	if c.Timeout < minTimeout {
+		return checks.ErrInvalidConfig{CheckName: c.For(), Field: "timeout", Reason: fmt.Sprintf("timeout must be at least %v", minTimeout)}
 	}
 
 	return nil

--- a/pkg/checks/health/config.go
+++ b/pkg/checks/health/config.go
@@ -19,6 +19,8 @@
 package health
 
 import (
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/caas-team/sparrow/internal/helper"
@@ -45,16 +47,18 @@ func (h *Config) For() string {
 
 // Validate checks if the configuration is valid
 func (h *Config) Validate() error {
-	if len(h.Targets) == 0 {
-		return checks.ErrInvalidConfig{Field: "targets", Reason: "no targets defined"}
+	for _, t := range h.Targets {
+		if !strings.HasPrefix(t, "https://") && !strings.HasPrefix(t, "http://") {
+			return checks.ErrInvalidConfig{Field: "targets", Reason: "target URLs must start with 'https://' or 'http://'"}
+		}
 	}
 
 	if h.Interval < minInterval {
-		return checks.ErrInvalidConfig{Field: "interval", Reason: "interval must be at least 100ms"}
+		return checks.ErrInvalidConfig{Field: "interval", Reason: fmt.Sprintf("interval must be at least %v", minInterval)}
 	}
 
 	if h.Timeout < minTimeout {
-		return checks.ErrInvalidConfig{Field: "timeout", Reason: "timeout must be at least 1s"}
+		return checks.ErrInvalidConfig{Field: "timeout", Reason: fmt.Sprintf("timeout must be at least %v", minTimeout)}
 	}
 
 	return nil

--- a/pkg/checks/health/config.go
+++ b/pkg/checks/health/config.go
@@ -1,0 +1,61 @@
+// sparrow
+// (C) 2024, Deutsche Telekom IT GmbH
+//
+// Deutsche Telekom IT GmbH and all other contributors /
+// copyright owners license this file to you under the Apache
+// License, Version 2.0 (the "License"); you may not use this
+// file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package health
+
+import (
+	"time"
+
+	"github.com/caas-team/sparrow/internal/helper"
+	"github.com/caas-team/sparrow/pkg/checks"
+)
+
+const (
+	minInterval = 100 * time.Millisecond
+	minTimeout  = 1 * time.Second
+)
+
+// Config defines the configuration parameters for a health check
+type Config struct {
+	Targets  []string           `json:"targets,omitempty" yaml:"targets,omitempty"`
+	Interval time.Duration      `json:"interval" yaml:"interval"`
+	Timeout  time.Duration      `json:"timeout" yaml:"timeout"`
+	Retry    helper.RetryConfig `json:"retry" yaml:"retry"`
+}
+
+// For returns the name of the check
+func (h *Config) For() string {
+	return CheckName
+}
+
+// Validate checks if the configuration is valid
+func (h *Config) Validate() error {
+	if len(h.Targets) == 0 {
+		return checks.ErrInvalidConfig{Field: "targets", Reason: "no targets defined"}
+	}
+
+	if h.Interval < minInterval {
+		return checks.ErrInvalidConfig{Field: "interval", Reason: "interval must be at least 100ms"}
+	}
+
+	if h.Timeout < minTimeout {
+		return checks.ErrInvalidConfig{Field: "timeout", Reason: "timeout must be at least 1s"}
+	}
+
+	return nil
+}

--- a/pkg/checks/health/config_test.go
+++ b/pkg/checks/health/config_test.go
@@ -39,6 +39,15 @@ func TestConfig_Validate(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "invalid targets",
+			config: Config{
+				Targets:  []string{"localhost:8080"},
+				Interval: 100 * time.Millisecond,
+				Timeout:  1 * time.Second,
+			},
+			wantErr: true,
+		},
+		{
 			name: "invalid interval",
 			config: Config{
 				Targets:  []string{"http://localhost:8080"},
@@ -53,15 +62,6 @@ func TestConfig_Validate(t *testing.T) {
 				Targets:  []string{"http://localhost:8080"},
 				Interval: 100 * time.Millisecond,
 				Timeout:  100 * time.Millisecond,
-			},
-			wantErr: true,
-		},
-		{
-			name: "no targets",
-			config: Config{
-				Targets:  []string{},
-				Interval: 100 * time.Millisecond,
-				Timeout:  1 * time.Second,
 			},
 			wantErr: true,
 		},

--- a/pkg/checks/health/config_test.go
+++ b/pkg/checks/health/config_test.go
@@ -1,0 +1,78 @@
+// sparrow
+// (C) 2024, Deutsche Telekom IT GmbH
+//
+// Deutsche Telekom IT GmbH and all other contributors /
+// copyright owners license this file to you under the Apache
+// License, Version 2.0 (the "License"); you may not use this
+// file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package health
+
+import (
+	"testing"
+	"time"
+)
+
+func TestConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  Config
+		wantErr bool
+	}{
+		{
+			name: "valid config",
+			config: Config{
+				Targets:  []string{"http://localhost:8080"},
+				Interval: 100 * time.Millisecond,
+				Timeout:  1 * time.Second,
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid interval",
+			config: Config{
+				Targets:  []string{"http://localhost:8080"},
+				Interval: 10 * time.Millisecond,
+				Timeout:  1 * time.Second,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid timeout",
+			config: Config{
+				Targets:  []string{"http://localhost:8080"},
+				Interval: 100 * time.Millisecond,
+				Timeout:  100 * time.Millisecond,
+			},
+			wantErr: true,
+		},
+		{
+			name: "no targets",
+			config: Config{
+				Targets:  []string{},
+				Interval: 100 * time.Millisecond,
+				Timeout:  1 * time.Second,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Config.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/checks/health/health.go
+++ b/pkg/checks/health/health.go
@@ -68,21 +68,9 @@ func NewCheck() checks.Check {
 	}
 }
 
-// Config defines the configuration parameters for a health check
-type Config struct {
-	Targets  []string           `json:"targets,omitempty" yaml:"targets,omitempty"`
-	Interval time.Duration      `json:"interval" yaml:"interval"`
-	Timeout  time.Duration      `json:"timeout" yaml:"timeout"`
-	Retry    helper.RetryConfig `json:"retry" yaml:"retry"`
-}
-
 // metrics contains the metric collectors for the Health check
 type metrics struct {
 	*prometheus.GaugeVec
-}
-
-func (h *Config) For() string {
-	return CheckName
 }
 
 // Run starts the health check

--- a/pkg/checks/latency/config.go
+++ b/pkg/checks/latency/config.go
@@ -1,0 +1,61 @@
+// sparrow
+// (C) 2024, Deutsche Telekom IT GmbH
+//
+// Deutsche Telekom IT GmbH and all other contributors /
+// copyright owners license this file to you under the Apache
+// License, Version 2.0 (the "License"); you may not use this
+// file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package latency
+
+import (
+	"time"
+
+	"github.com/caas-team/sparrow/internal/helper"
+	"github.com/caas-team/sparrow/pkg/checks"
+)
+
+const (
+	minInterval = 100 * time.Millisecond
+	minTimeout  = 1 * time.Second
+)
+
+// Config defines the configuration parameters for a latency check
+type Config struct {
+	Targets  []string           `json:"targets,omitempty" yaml:"targets,omitempty"`
+	Interval time.Duration      `json:"interval" yaml:"interval"`
+	Timeout  time.Duration      `json:"timeout" yaml:"timeout"`
+	Retry    helper.RetryConfig `json:"retry" yaml:"retry"`
+}
+
+// For returns the name of the check
+func (l *Config) For() string {
+	return CheckName
+}
+
+// Validate checks if the configuration is valid
+func (h *Config) Validate() error {
+	if len(h.Targets) == 0 {
+		return checks.ErrInvalidConfig{Field: "targets", Reason: "no targets defined"}
+	}
+
+	if h.Interval < minInterval {
+		return checks.ErrInvalidConfig{Field: "interval", Reason: "interval must be at least 100ms"}
+	}
+
+	if h.Timeout < minTimeout {
+		return checks.ErrInvalidConfig{Field: "timeout", Reason: "timeout must be at least 1s"}
+	}
+
+	return nil
+}

--- a/pkg/checks/latency/config.go
+++ b/pkg/checks/latency/config.go
@@ -41,24 +41,24 @@ type Config struct {
 }
 
 // For returns the name of the check
-func (l *Config) For() string {
+func (c *Config) For() string {
 	return CheckName
 }
 
 // Validate checks if the configuration is valid
-func (h *Config) Validate() error {
-	for _, t := range h.Targets {
+func (c *Config) Validate() error {
+	for _, t := range c.Targets {
 		if !strings.HasPrefix(t, "https://") && !strings.HasPrefix(t, "http://") {
-			return checks.ErrInvalidConfig{Field: "targets", Reason: "target URLs must start with 'https://' or 'http://'"}
+			return checks.ErrInvalidConfig{CheckName: c.For(), Field: "targets", Reason: "target URLs must start with 'https://' or 'http://'"}
 		}
 	}
 
-	if h.Interval < minInterval {
-		return checks.ErrInvalidConfig{Field: "interval", Reason: fmt.Sprintf("interval must be at least %v", minInterval)}
+	if c.Interval < minInterval {
+		return checks.ErrInvalidConfig{CheckName: c.For(), Field: "interval", Reason: fmt.Sprintf("interval must be at least %v", minInterval)}
 	}
 
-	if h.Timeout < minTimeout {
-		return checks.ErrInvalidConfig{Field: "timeout", Reason: fmt.Sprintf("timeout must be at least %v", minTimeout)}
+	if c.Timeout < minTimeout {
+		return checks.ErrInvalidConfig{CheckName: c.For(), Field: "timeout", Reason: fmt.Sprintf("timeout must be at least %v", minTimeout)}
 	}
 
 	return nil

--- a/pkg/checks/latency/config.go
+++ b/pkg/checks/latency/config.go
@@ -19,6 +19,8 @@
 package latency
 
 import (
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/caas-team/sparrow/internal/helper"
@@ -45,16 +47,18 @@ func (l *Config) For() string {
 
 // Validate checks if the configuration is valid
 func (h *Config) Validate() error {
-	if len(h.Targets) == 0 {
-		return checks.ErrInvalidConfig{Field: "targets", Reason: "no targets defined"}
+	for _, t := range h.Targets {
+		if !strings.HasPrefix(t, "https://") && !strings.HasPrefix(t, "http://") {
+			return checks.ErrInvalidConfig{Field: "targets", Reason: "target URLs must start with 'https://' or 'http://'"}
+		}
 	}
 
 	if h.Interval < minInterval {
-		return checks.ErrInvalidConfig{Field: "interval", Reason: "interval must be at least 100ms"}
+		return checks.ErrInvalidConfig{Field: "interval", Reason: fmt.Sprintf("interval must be at least %v", minInterval)}
 	}
 
 	if h.Timeout < minTimeout {
-		return checks.ErrInvalidConfig{Field: "timeout", Reason: "timeout must be at least 1s"}
+		return checks.ErrInvalidConfig{Field: "timeout", Reason: fmt.Sprintf("timeout must be at least %v", minTimeout)}
 	}
 
 	return nil

--- a/pkg/checks/latency/config_test.go
+++ b/pkg/checks/latency/config_test.go
@@ -39,6 +39,15 @@ func TestConfig_Validate(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "invalid targets",
+			config: Config{
+				Targets:  []string{"localhost:8080"},
+				Interval: 100 * time.Millisecond,
+				Timeout:  1 * time.Second,
+			},
+			wantErr: true,
+		},
+		{
 			name: "invalid interval",
 			config: Config{
 				Targets:  []string{"http://localhost:8080"},
@@ -53,15 +62,6 @@ func TestConfig_Validate(t *testing.T) {
 				Targets:  []string{"http://localhost:8080"},
 				Interval: 100 * time.Millisecond,
 				Timeout:  100 * time.Millisecond,
-			},
-			wantErr: true,
-		},
-		{
-			name: "no targets",
-			config: Config{
-				Targets:  []string{},
-				Interval: 100 * time.Millisecond,
-				Timeout:  1 * time.Second,
 			},
 			wantErr: true,
 		},

--- a/pkg/checks/latency/config_test.go
+++ b/pkg/checks/latency/config_test.go
@@ -1,0 +1,78 @@
+// sparrow
+// (C) 2024, Deutsche Telekom IT GmbH
+//
+// Deutsche Telekom IT GmbH and all other contributors /
+// copyright owners license this file to you under the Apache
+// License, Version 2.0 (the "License"); you may not use this
+// file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package latency
+
+import (
+	"testing"
+	"time"
+)
+
+func TestConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  Config
+		wantErr bool
+	}{
+		{
+			name: "valid config",
+			config: Config{
+				Targets:  []string{"http://localhost:8080"},
+				Interval: 100 * time.Millisecond,
+				Timeout:  1 * time.Second,
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid interval",
+			config: Config{
+				Targets:  []string{"http://localhost:8080"},
+				Interval: 10 * time.Millisecond,
+				Timeout:  1 * time.Second,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid timeout",
+			config: Config{
+				Targets:  []string{"http://localhost:8080"},
+				Interval: 100 * time.Millisecond,
+				Timeout:  100 * time.Millisecond,
+			},
+			wantErr: true,
+		},
+		{
+			name: "no targets",
+			config: Config{
+				Targets:  []string{},
+				Interval: 100 * time.Millisecond,
+				Timeout:  1 * time.Second,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Config.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/checks/latency/latency.go
+++ b/pkg/checks/latency/latency.go
@@ -63,18 +63,6 @@ func NewCheck() checks.Check {
 	}
 }
 
-// Config defines the configuration parameters for a latency check
-type Config struct {
-	Targets  []string           `json:"targets,omitempty" yaml:"targets,omitempty"`
-	Interval time.Duration      `json:"interval" yaml:"interval"`
-	Timeout  time.Duration      `json:"timeout" yaml:"timeout"`
-	Retry    helper.RetryConfig `json:"retry" yaml:"retry"`
-}
-
-func (l *Config) For() string {
-	return CheckName
-}
-
 // result represents the result of a single latency check for a specific target
 type result struct {
 	Code  int     `json:"code"`

--- a/pkg/factory/factory.go
+++ b/pkg/factory/factory.go
@@ -34,9 +34,14 @@ func newCheck(cfg checks.Runtime) (checks.Check, error) {
 		return nil, errors.New("config is nil")
 	}
 
+	err := cfg.Validate()
+	if err != nil {
+		return nil, err
+	}
+
 	if f, ok := registry[cfg.For()]; ok {
 		c := f()
-		err := c.SetConfig(cfg)
+		err = c.SetConfig(cfg)
 		return c, err
 	}
 	return nil, errors.New("unknown check type")

--- a/pkg/sparrow/run_test.go
+++ b/pkg/sparrow/run_test.go
@@ -57,7 +57,9 @@ func TestSparrow_ReconcileChecks(t *testing.T) {
 			checks: map[string]checks.Check{},
 
 			newRuntimeConfig: runtime.Config{Health: &health.Config{
-				Targets: []string{"https://gitlab.com"},
+				Targets:  []string{"https://gitlab.com"},
+				Interval: 1 * time.Second,
+				Timeout:  1 * time.Second,
 			}},
 		},
 		{
@@ -65,13 +67,19 @@ func TestSparrow_ReconcileChecks(t *testing.T) {
 			checks: map[string]checks.Check{},
 			newRuntimeConfig: runtime.Config{
 				Health: &health.Config{
-					Targets: []string{"https://gitlab.com"},
+					Targets:  []string{"https://gitlab.com"},
+					Interval: 1 * time.Second,
+					Timeout:  1 * time.Second,
 				},
 				Latency: &latency.Config{
-					Targets: []string{"https://gitlab.com"},
+					Targets:  []string{"https://gitlab.com"},
+					Interval: 1 * time.Second,
+					Timeout:  1 * time.Second,
 				},
 				Dns: &dns.Config{
-					Targets: []string{"gitlab.com"},
+					Targets:  []string{"gitlab.com"},
+					Interval: 1 * time.Second,
+					Timeout:  1 * time.Second,
 				},
 			},
 		},
@@ -84,10 +92,14 @@ func TestSparrow_ReconcileChecks(t *testing.T) {
 
 			newRuntimeConfig: runtime.Config{
 				Latency: &latency.Config{
-					Targets: []string{"https://gitlab.com"},
+					Targets:  []string{"https://gitlab.com"},
+					Interval: 1 * time.Second,
+					Timeout:  1 * time.Second,
 				},
 				Health: &health.Config{
-					Targets: []string{"https://gitlab.com"},
+					Targets:  []string{"https://gitlab.com"},
+					Interval: 1 * time.Second,
+					Timeout:  1 * time.Second,
 				},
 			},
 		},
@@ -109,7 +121,9 @@ func TestSparrow_ReconcileChecks(t *testing.T) {
 
 			newRuntimeConfig: runtime.Config{
 				Latency: &latency.Config{
-					Targets: []string{"https://gitlab.com"},
+					Targets:  []string{"https://gitlab.com"},
+					Interval: 1 * time.Second,
+					Timeout:  1 * time.Second,
 				},
 			},
 		},


### PR DESCRIPTION
## Motivation

To validate the configuration options for each check and abort reconcilation if they're invalid.

Closes #97 

## Changes

Not much, I've added a `Validate` function to the `checks.Runtime` interface so every check implements its own validation logic. Then I'm validating the config in the check factory before initializing the check. 

For additional information look at the commits.

## Tests done

I've provided some unit tests for each config validation.

## TODO

- [x] I've assigned this PR to myself
- [x] I've labeled this PR correctly

<!-- Add open ToDo's to this checklist -->