### PR TITLE
refactor: use one result channel for all checks

### DIFF
--- a/pkg/checks/base.go
+++ b/pkg/checks/base.go
@@ -41,11 +41,9 @@ type Check interface {
 	// Run is called once, to start running the check. The check should
 	// run until the context is canceled and handle problems itself.
 	// Returning a non-nil error will cause the shutdown of the check.
-	Run(ctx context.Context) error
+	Run(ctx context.Context, cResult chan ResultDTO) error
 	// Shutdown is called once when the check is unregistered or sparrow shuts down
 	Shutdown(ctx context.Context) error
-	// ResultChan returns the channel where the check sends its results to
-	ResultChan() chan Result
 	// SetConfig is called once when the check is registered
 	// This is also called while the check is running, if the remote config is updated
 	// This should return an error if the config is invalid
@@ -65,8 +63,6 @@ type Check interface {
 type CheckBase struct {
 	// Mutex for thread-safe access to shared resources within the check implementation
 	Mu sync.Mutex
-	// Essential for passing check results back to the Sparrow; must be utilized by Check implementations
-	ResChan chan Result
 	// Signal channel used to notify about shutdown of a check
 	DoneChan chan struct{}
 }

--- a/pkg/checks/base.go
+++ b/pkg/checks/base.go
@@ -75,13 +75,10 @@ type Runtime interface {
 
 // Result encapsulates the outcome of a check run.
 type Result struct {
-	// data contains performance metrics about the check run
+	// Data contains performance metrics about the check run
 	Data any `json:"data"`
 	// Timestamp is the UTC time the check was run
 	Timestamp time.Time `json:"timestamp"`
-	// Err should be nil if the check ran successfully indicating the check is "healthy"
-	// if the check failed, this should be an error message that will be logged and returned to an API user
-	Err string `json:"error"`
 }
 
 // ResultDTO is a data transfer object used to associate a check's name with its result.

--- a/pkg/checks/base_moq.go
+++ b/pkg/checks/base_moq.go
@@ -29,10 +29,7 @@ var _ Check = &CheckMock{}
 //			NameFunc: func() string {
 //				panic("mock out the Name method")
 //			},
-//			ResultChanFunc: func() chan Result {
-//				panic("mock out the ResultChan method")
-//			},
-//			RunFunc: func(ctx context.Context) error {
+//			RunFunc: func(ctx context.Context, cResult chan ResultDTO) error {
 //				panic("mock out the Run method")
 //			},
 //			SchemaFunc: func() (*openapi3.SchemaRef, error) {
@@ -60,11 +57,8 @@ type CheckMock struct {
 	// NameFunc mocks the Name method.
 	NameFunc func() string
 
-	// ResultChanFunc mocks the ResultChan method.
-	ResultChanFunc func() chan Result
-
 	// RunFunc mocks the Run method.
-	RunFunc func(ctx context.Context) error
+	RunFunc func(ctx context.Context, cResult chan ResultDTO) error
 
 	// SchemaFunc mocks the Schema method.
 	SchemaFunc func() (*openapi3.SchemaRef, error)
@@ -86,13 +80,12 @@ type CheckMock struct {
 		// Name holds details about calls to the Name method.
 		Name []struct {
 		}
-		// ResultChan holds details about calls to the ResultChan method.
-		ResultChan []struct {
-		}
 		// Run holds details about calls to the Run method.
 		Run []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
+			// CResult is the cResult argument value.
+			CResult chan ResultDTO
 		}
 		// Schema holds details about calls to the Schema method.
 		Schema []struct {
@@ -111,7 +104,6 @@ type CheckMock struct {
 	lockGetConfig           sync.RWMutex
 	lockGetMetricCollectors sync.RWMutex
 	lockName                sync.RWMutex
-	lockResultChan          sync.RWMutex
 	lockRun                 sync.RWMutex
 	lockSchema              sync.RWMutex
 	lockSetConfig           sync.RWMutex
@@ -199,47 +191,22 @@ func (mock *CheckMock) NameCalls() []struct {
 	return calls
 }
 
-// ResultChan calls ResultChanFunc.
-func (mock *CheckMock) ResultChan() chan Result {
-	if mock.ResultChanFunc == nil {
-		panic("CheckMock.ResultChanFunc: method is nil but Check.ResultChan was just called")
-	}
-	callInfo := struct {
-	}{}
-	mock.lockResultChan.Lock()
-	mock.calls.ResultChan = append(mock.calls.ResultChan, callInfo)
-	mock.lockResultChan.Unlock()
-	return mock.ResultChanFunc()
-}
-
-// ResultChanCalls gets all the calls that were made to ResultChan.
-// Check the length with:
-//
-//	len(mockedCheck.ResultChanCalls())
-func (mock *CheckMock) ResultChanCalls() []struct {
-} {
-	var calls []struct {
-	}
-	mock.lockResultChan.RLock()
-	calls = mock.calls.ResultChan
-	mock.lockResultChan.RUnlock()
-	return calls
-}
-
 // Run calls RunFunc.
-func (mock *CheckMock) Run(ctx context.Context) error {
+func (mock *CheckMock) Run(ctx context.Context, cResult chan ResultDTO) error {
 	if mock.RunFunc == nil {
 		panic("CheckMock.RunFunc: method is nil but Check.Run was just called")
 	}
 	callInfo := struct {
-		Ctx context.Context
+		Ctx     context.Context
+		CResult chan ResultDTO
 	}{
-		Ctx: ctx,
+		Ctx:     ctx,
+		CResult: cResult,
 	}
 	mock.lockRun.Lock()
 	mock.calls.Run = append(mock.calls.Run, callInfo)
 	mock.lockRun.Unlock()
-	return mock.RunFunc(ctx)
+	return mock.RunFunc(ctx, cResult)
 }
 
 // RunCalls gets all the calls that were made to Run.
@@ -247,10 +214,12 @@ func (mock *CheckMock) Run(ctx context.Context) error {
 //
 //	len(mockedCheck.RunCalls())
 func (mock *CheckMock) RunCalls() []struct {
-	Ctx context.Context
+	Ctx     context.Context
+	CResult chan ResultDTO
 } {
 	var calls []struct {
-		Ctx context.Context
+		Ctx     context.Context
+		CResult chan ResultDTO
 	}
 	mock.lockRun.RLock()
 	calls = mock.calls.Run

--- a/pkg/checks/dns/dns_test.go
+++ b/pkg/checks/dns/dns_test.go
@@ -193,9 +193,6 @@ func TestDNS_Run(t *testing.T) {
 			}()
 
 			r := <-cResult
-			if r.Result.Err != tt.want.Err {
-				t.Errorf("DNS.Run() = %v, want %v", r.Result.Err, tt.want.Err)
-			}
 			assert.IsType(t, tt.want.Data, r.Result.Data)
 
 			got := r.Result.Data.(map[string]result)

--- a/pkg/checks/dns/dns_test.go
+++ b/pkg/checks/dns/dns_test.go
@@ -53,7 +53,6 @@ func TestDNS_Run(t *testing.T) {
 				return &DNS{
 					CheckBase: checks.CheckBase{
 						Mu:       sync.Mutex{},
-						ResChan:  make(chan checks.Result, 1),
 						DoneChan: make(chan struct{}, 1),
 					},
 				}
@@ -166,6 +165,9 @@ func TestDNS_Run(t *testing.T) {
 			ctx := context.Background()
 			c := tt.mockSetup()
 
+			cResult := make(chan checks.ResultDTO, 1)
+			defer close(cResult)
+
 			err := c.SetConfig(&Config{
 				Targets:  tt.targets,
 				Interval: 1 * time.Second,
@@ -176,7 +178,7 @@ func TestDNS_Run(t *testing.T) {
 			}
 
 			go func() {
-				err := c.Run(ctx)
+				err := c.Run(ctx, cResult)
 				if err != nil {
 					t.Errorf("DNS.Run() error = %v", err)
 					return
@@ -190,13 +192,13 @@ func TestDNS_Run(t *testing.T) {
 				}
 			}()
 
-			r := <-c.ResultChan()
-			if r.Err != tt.want.Err {
-				t.Errorf("DNS.Run() = %v, want %v", r.Err, tt.want.Err)
+			r := <-cResult
+			if r.Result.Err != tt.want.Err {
+				t.Errorf("DNS.Run() = %v, want %v", r.Result.Err, tt.want.Err)
 			}
-			assert.IsType(t, tt.want.Data, r.Data)
+			assert.IsType(t, tt.want.Data, r.Result.Data)
 
-			got := r.Data.(map[string]result)
+			got := r.Result.Data.(map[string]result)
 			want := tt.want.Data.(map[string]result)
 			if len(got) != len(want) {
 				t.Errorf("Length of DNS.Run() result set (%v) does not match length of expected result set (%v)", len(got), len(want))
@@ -217,16 +219,21 @@ func TestDNS_Run(t *testing.T) {
 }
 
 func TestDNS_Run_Context_Done(t *testing.T) {
-	c := NewCheck()
 	ctx, cancel := context.WithCancel(context.Background())
+
+	c := NewCheck()
+	cResult := make(chan checks.ResultDTO, 1)
+	defer close(cResult)
+
 	err := c.SetConfig(&Config{
 		Interval: time.Second,
 	})
 	if err != nil {
 		t.Fatalf("DNS.SetConfig() error = %v", err)
 	}
+
 	go func() {
-		err := c.Run(ctx)
+		err := c.Run(ctx, cResult)
 		t.Logf("DNS.Run() exited with error: %v", err)
 		if err == nil {
 			t.Error("DNS.Run() should have errored out, no error received")
@@ -241,24 +248,10 @@ func TestDNS_Run_Context_Done(t *testing.T) {
 	time.Sleep(time.Millisecond * 30)
 }
 
-func TestDNS_ResultChan(t *testing.T) {
-	c := DNS{
-		CheckBase: checks.CheckBase{
-			ResChan: make(chan checks.Result, 1),
-		},
-	}
-
-	rc := c.ResultChan()
-	if rc != c.ResChan {
-		t.Errorf("ResultChan() got = %v, want %v", rc, c.ResChan)
-	}
-}
-
 func TestDNS_Shutdown(t *testing.T) {
 	cDone := make(chan struct{}, 1)
 	c := DNS{
 		CheckBase: checks.CheckBase{
-			ResChan:  make(chan checks.Result, 1),
 			DoneChan: cDone,
 		},
 	}
@@ -341,7 +334,6 @@ func newCommonDNS() *DNS {
 	return &DNS{
 		CheckBase: checks.CheckBase{
 			Mu:       sync.Mutex{},
-			ResChan:  make(chan checks.Result, 1),
 			DoneChan: make(chan struct{}, 1),
 		},
 		metrics: newMetrics(),

--- a/pkg/checks/health/health_test.go
+++ b/pkg/checks/health/health_test.go
@@ -252,7 +252,6 @@ func TestHealth_Shutdown(t *testing.T) {
 	cDone := make(chan struct{}, 1)
 	c := Health{
 		CheckBase: checks.CheckBase{
-			ResChan:  make(chan checks.Result, 1),
 			DoneChan: cDone,
 		},
 	}

--- a/pkg/checks/latency/latency.go
+++ b/pkg/checks/latency/latency.go
@@ -53,7 +53,6 @@ func NewCheck() checks.Check {
 	return &Latency{
 		CheckBase: checks.CheckBase{
 			Mu:       sync.Mutex{},
-			ResChan:  make(chan checks.Result, 1),
 			DoneChan: make(chan struct{}, 1),
 		},
 		config: Config{
@@ -90,7 +89,7 @@ type metrics struct {
 }
 
 // Run starts the latency check
-func (l *Latency) Run(ctx context.Context) error {
+func (l *Latency) Run(ctx context.Context, cResult chan checks.ResultDTO) error {
 	ctx, cancel := logger.NewContextWithLogger(ctx)
 	defer cancel()
 	log := logger.FromContext(ctx)
@@ -105,14 +104,14 @@ func (l *Latency) Run(ctx context.Context) error {
 			return nil
 		case <-time.After(l.config.Interval):
 			res := l.check(ctx)
-			errval := ""
-			r := checks.Result{
-				Data:      res,
-				Err:       errval,
-				Timestamp: time.Now(),
-			}
 
-			l.ResChan <- r
+			cResult <- checks.ResultDTO{
+				Name: l.Name(),
+				Result: &checks.Result{
+					Data:      res,
+					Timestamp: time.Now(),
+				},
+			}
 			log.Debug("Successfully finished latency check run")
 		}
 	}
@@ -121,13 +120,8 @@ func (l *Latency) Run(ctx context.Context) error {
 func (l *Latency) Shutdown(_ context.Context) error {
 	l.DoneChan <- struct{}{}
 	close(l.DoneChan)
-	close(l.ResChan)
 
 	return nil
-}
-
-func (l *Latency) ResultChan() chan checks.Result {
-	return l.ResChan
 }
 
 // SetConfig sets the configuration for the latency check

--- a/pkg/checks/latency/latency_test.go
+++ b/pkg/checks/latency/latency_test.go
@@ -77,7 +77,6 @@ func TestLatency_Run(t *testing.T) {
 					successURL: {Code: http.StatusOK, Error: nil, Total: 0},
 				},
 				Timestamp: time.Time{},
-				Err:       "",
 			},
 		},
 		{
@@ -112,7 +111,6 @@ func TestLatency_Run(t *testing.T) {
 					timeoutURL: {Code: 0, Error: stringPointer(fmt.Sprintf("Get %q: context deadline exceeded", timeoutURL)), Total: 0},
 				},
 				Timestamp: time.Time{},
-				Err:       "",
 			},
 		},
 	}
@@ -180,9 +178,6 @@ func TestLatency_Run(t *testing.T) {
 				}
 			}
 
-			if res.Result.Err != tt.want.Err {
-				t.Errorf("Latency.Run() = %v, want %v", res.Result.Err, tt.want.Err)
-			}
 			httpmock.Reset()
 		})
 	}

--- a/pkg/checks/oapi_test.go
+++ b/pkg/checks/oapi_test.go
@@ -36,7 +36,20 @@ func TestOpenapiFromPerfData(t *testing.T) {
 		wantErr bool
 	}
 	tests := []cases[string]{
-		{name: "int", args: args[string]{perfData: "hello world"}, want: &openapi3.SchemaRef{Value: openapi3.NewObjectSchema().WithProperties(map[string]*openapi3.Schema{"error": {Type: "string"}, "data": {Type: "string"}, "timestamp": {Type: "string", Format: "date-time"}})}, wantErr: false},
+		{
+			name: "int",
+			args: args[string]{perfData: "hello world"},
+			want: &openapi3.SchemaRef{
+				Value: openapi3.NewObjectSchema().WithProperties(map[string]*openapi3.Schema{
+					"data": {Type: "string"},
+					"timestamp": {
+						Type:   "string",
+						Format: "date-time",
+					},
+				}),
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/sparrow/handlers_test.go
+++ b/pkg/sparrow/handlers_test.go
@@ -172,8 +172,8 @@ func chiRequest(r *http.Request, value string) *http.Request {
 
 func testDb() *db.InMemory {
 	d := db.NewInMemory()
-	d.Save(checks.ResultDTO{Name: "alpha", Result: &checks.Result{Timestamp: time.Now(), Err: "", Data: 1}})
-	d.Save(checks.ResultDTO{Name: "beta", Result: &checks.Result{Timestamp: time.Now(), Err: "", Data: 1}})
+	d.Save(checks.ResultDTO{Name: "alpha", Result: &checks.Result{Timestamp: time.Now(), Data: 1}})
+	d.Save(checks.ResultDTO{Name: "beta", Result: &checks.Result{Timestamp: time.Now(), Data: 1}})
 
 	return d
 }

--- a/pkg/sparrow/run.go
+++ b/pkg/sparrow/run.go
@@ -108,7 +108,7 @@ func (s *Sparrow) Run(ctx context.Context) error {
 	}()
 
 	go func() {
-		s.cErr <- s.controller.HandleErrors(ctx)
+		s.cErr <- s.controller.Run(ctx)
 	}()
 
 	for {


### PR DESCRIPTION
## Motivation

Addresses this discussion: https://github.com/caas-team/sparrow/pull/102#discussion_r1484805340

## Changes

I've removed the result channels of each check. Instead I'm giving the result channel to the `Run` method of each check.

For additional information look at the commits.

## Tests done

Unit tests succeeded.

## TODO

- [x] I've assigned this PR to myself
- [x] I've labeled this PR correctly

<!-- Add open ToDo's to this checklist -->