### PR TITLE
chore: prepare new release

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,11 @@ curl https://github.com/caas-team/sparrow/releases/download/v${RELEASE_VERSION}/
 curl https://github.com/caas-team/sparrow/releases/download/v${RELEASE_VERSION}/sparrow_${RELEASE_VERSION}_checksums.txt -Lo checksums.txt
 ```
 
-For example, for release `v0.3.0`:
+For example, for release `v0.3.1`:
 
 ```sh
-curl https://github.com/caas-team/sparrow/releases/download/v0.3.0/sparrow_0.3.0_linux_amd64.tar.gz -Lo sparrow.tar.gz
-curl https://github.com/caas-team/sparrow/releases/download/v0.3.0/sparrow_0.3.0_checksums.txt -Lo checksums.txt
+curl https://github.com/caas-team/sparrow/releases/download/v0.3.1/sparrow_0.3.1_linux_amd64.tar.gz -Lo sparrow.tar.gz
+curl https://github.com/caas-team/sparrow/releases/download/v0.3.1/sparrow_0.3.1_checksums.txt -Lo checksums.txt
 ```
 
 Extract the binary:
@@ -95,7 +95,7 @@ dedicated [release](https://github.com/caas-team/sparrow/releases) can be found 
 Sparrow can be installed via Helm Chart. The chart is available in the GitHub registry:
 
 ```sh
-helm -n sparrow upgrade -i sparrow oci://ghcr.io/caas-team/charts/sparrow --version 1.0.0 --create-namespace
+helm -n sparrow upgrade -i sparrow oci://ghcr.io/caas-team/charts/sparrow --version 0.0.4 --create-namespace
 ```
 
 The default settings are suitable for a local configuration. With the default Helm values, the sparrow loader uses a
@@ -182,9 +182,6 @@ Just write out the path to the attribute, delimited by `_`.
 
 You can set the `LOG_LEVEL` environment variable to adjust the log level.
 
-To be able to load the configuration for the [checks](#checks) during runtime dynamically, the sparrow loader needs to
-be set to type `http`.
-
 #### Example startup configuration
 
 ```yaml
@@ -260,7 +257,7 @@ Available loaders:
 - `http` (default): Retrieves the checks' configuration from a remote endpoint during runtime. Additional configuration
   parameters are set in the `loader.http` section.
 
-- `file`: Loads the configuration from a local file during runtime. Additional configuration
+- `file`: Loads the checks' configuration from a local file during runtime. Additional configuration
   parameters are set in the `loader.file` section.
 
 If you want to retrieve the checks' configuration only once, you can set `loader.interval` to 0.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ dedicated [release](https://github.com/caas-team/sparrow/releases) can be found 
 Sparrow can be installed via Helm Chart. The chart is available in the GitHub registry:
 
 ```sh
-helm -n sparrow upgrade -i sparrow oci://ghcr.io/caas-team/charts/sparrow --version 0.0.4 --create-namespace
+helm -n sparrow upgrade -i sparrow oci://ghcr.io/caas-team/charts/sparrow --create-namespace
 ```
 
 The default settings are suitable for a local configuration. With the default Helm values, the sparrow loader uses a

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 keywords:
   - monitoring
 version: 0.0.4
-appVersion: "v0.3.0"
+appVersion: "v0.3.1"
 icon: https://github.com/caas-team/sparrow/blob/main/docs/img/sparrow.png
 sources:
   - https://github.com/caas-team/sparrow

--- a/chart/README.md
+++ b/chart/README.md
@@ -1,6 +1,6 @@
 # sparrow
 
-![Version: 0.0.4](https://img.shields.io/badge/Version-0.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.0](https://img.shields.io/badge/AppVersion-v0.3.0-informational?style=flat-square)
+![Version: 0.0.4](https://img.shields.io/badge/Version-0.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.1](https://img.shields.io/badge/AppVersion-v0.3.1-informational?style=flat-square)
 
 A Helm chart to install Sparrow
 
@@ -62,6 +62,6 @@ A Helm chart to install Sparrow
 | serviceMonitor.interval | string | `"30s"` | Sets the scrape interval |
 | serviceMonitor.labels | object | `{}` | Additional label added to the service Monitor |
 | serviceMonitor.scrapeTimeout | string | `"5s"` | Sets the scrape timeout |
-| sparrowConfig | object | `{"loader":{"path":"/config/checks.yaml","type":"file"},"name":"sparrow.com"}` | Sparrow configuration read on startup see: https://github.com/caas-team/sparrow/blob/main/docs/sparrow_run.md |
+| sparrowConfig | object | `{"loader":{"file":{"path":"/config/checks.yaml"},"type":"file"},"name":"sparrow.com"}` | Sparrow configuration read on startup see: https://github.com/caas-team/sparrow/blob/main/docs/sparrow_run.md |
 | tolerations | list | `[]` |  |
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -111,21 +111,23 @@ sparrowConfig:
   name: sparrow.com
   loader:
     type: file
-    path: /config/checks.yaml
-# name: the-sparrow.com
+    file:
+      path: /config/checks.yaml
+# name: sparrow.com
 # api:
 #   address:
 # loader:
 #   type: http | file
-#   interval:
+#   interval: 30s
 #   http:
-#     url:
-#     token:
-#     timeout:
-#     retryCount:
-#     retryDelay:
+#     url: ""
+#     token: ""
+#     timeout: 30s
+#     retry:
+#       delay: 10s
+#       count: 5
 #   file:
-#     path: /runconfig/checks.yaml
+#     path: /config/checks.yaml
 # targetManager:
 #   checkInterval: 300s
 #   unhealthyThreshold: 600s
@@ -139,33 +141,33 @@ sparrowConfig:
 # -- Check configuration of the Sparrow read on runtime
 # see: https://github.com/caas-team/sparrow?tab=readme-ov-file#checks
 checksConfig: {}
-#  health:
-#     interval: 15s
-#     timeout: 10s
-#     retry:
-#       count: 3
-#       delay: 1s
-#     targets:
-#       - "https://www.example.com/"
-#       - "https://www.google.com/"
-#  latency:
-#     interval: 15s
-#     timeout: 30s
-#     retry:
-#       count: 3
-#       delay: 2s
-#     targets:
-#       - https://example.com/
-#       - https://google.com/
-#   dns:
-#     interval: 10s
-#     timeout: 30s
-#     retry:
-#       count: 5
-#       delay: 1s
-#     targets:
-#       - www.example.com
-#       - www.google.com
+# health:
+#   interval: 15s
+#   timeout: 10s
+#   retry:
+#     count: 3
+#     delay: 1s
+#   targets:
+#     - "https://www.example.com/"
+#     - "https://www.google.com/"
+# latency:
+#   interval: 15s
+#   timeout: 30s
+#   retry:
+#     count: 3
+#     delay: 2s
+#   targets:
+#     - https://example.com/
+#     - https://google.com/
+# dns:
+#   interval: 10s
+#   timeout: 30s
+#   retry:
+#     count: 5
+#     delay: 1s
+#   targets:
+#     - www.example.com
+#     - www.google.com
 
 # -- Configure a service monitor for prometheus-operator
 serviceMonitor:


### PR DESCRIPTION
## Motivation

To prepare the new release, the chart's `appVersion` needs to be bumped and the docs need to be adjusted.

## Changes

I've bumped the `appVersion` and adjusted the docs. 

I've also adjusted some of the default values in the chart to be aligned with the configuration options of the docs. The values before were rather confusing to new users.

* chore: bump chart app version
* fix: sparrow config values for chart
* docs: adjust docs to new release

For additional information look at the commits.

## Tests done

The sparrow deploys successfully with the newest image of the `main` branch.

```sh
$ helm upgrade sparrow ./chart/ -i --set image.tag=commit-ae8c61e -n sparrow --create-namespace
Release "sparrow" does not exist. Installing it now.
NAME: sparrow
LAST DEPLOYED: Wed Feb 21 12:11:14 2024
NAMESPACE: sparrow
STATUS: deployed
REVISION: 1
TEST SUITE: None
```

## TODO

- [x] I've assigned this PR to myself
- [x] I've labeled this PR correctly

<!-- Add open ToDo's to this checklist -->