### PR TITLE
Targetmanager doesn't need timer reset

### DIFF
--- a/pkg/sparrow/targets/gitlab.go
+++ b/pkg/sparrow/targets/gitlab.go
@@ -97,19 +97,16 @@ func (t *gitlabTargetManager) Reconcile(ctx context.Context) error {
 			if err != nil {
 				log.Warn("Failed to get global targets", "error", err)
 			}
-			checkTimer.Reset(t.cfg.CheckInterval)
 		case <-registrationTimer.C:
 			err := t.register(ctx)
 			if err != nil {
 				log.Warn("Failed to register self as global target", "error", err)
 			}
-			registrationTimer.Reset(t.cfg.RegistrationInterval)
 		case <-updateTimer.C:
 			err := t.update(ctx)
 			if err != nil {
 				log.Warn("Failed to update registration", "error", err)
 			}
-			updateTimer.Reset(t.cfg.UpdateInterval)
 		}
 	}
 }


### PR DESCRIPTION
## Motivation

The reset timers are unnecessary. The timers carry on automatically and there is no need to reset them. 

## Changes

Removed the reset call from the timers.

## TODO

- [x] I've assigned this PR to myself
- [x] I've labeled this PR correctly

<!-- Add open ToDo's to this checklist -->