### PR TITLE
chore: bump go v1.22 & general housekeeping

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,6 +12,9 @@ For additional information look at the commits.
 
 <!-- Explain what tests you've done and if your tests worked -->
 
+- [ ] Unit tests succeeded
+- [ ] E2E tests succeeded
+
 ## TODO
 
 - [ ] I've assigned this PR to myself

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,17 +13,10 @@ jobs:
   rel:
     name: Build, scan & push Snapshot
     runs-on: ubuntu-latest
-
-    permissions:
-      contents: write
-      packages: write
-      security-events: write
-
     steps:
-
       - name: Checkout repository
         uses: actions/checkout@v4
-      
+
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
@@ -44,7 +37,7 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: "ghcr.io/caas-team/sparrow:${{ steps.version.outputs.value }}"
+          image-ref: "ghcr.io/${{ github.repository }}:${{ steps.version.outputs.value }}"
           format: "sarif"
           output: "trivy-results.sarif"
 
@@ -61,7 +54,8 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push snapshot container image
-        run: docker push ghcr.io/caas-team/sparrow:${{ steps.version.outputs.value }}
+        run: docker push ghcr.io/${{ github.repository }}:${{ steps.version.outputs.value }}
+
   helm:
     runs-on: ubuntu-latest
     steps:
@@ -75,7 +69,7 @@ jobs:
 
       - name: Get App Version
         id: appVersion
-        run:  echo "value=commit-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+        run: echo "value=commit-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Get Chart Version
         id: chartVersion
@@ -87,9 +81,9 @@ jobs:
 
       - name: Helm lint
         run: helm lint ./chart
-      
+
       - name: Helm package
         run: helm package ./chart -d ./chart --version ${{ steps.chartVersion.outputs.value }} --app-version ${{ steps.appVersion.outputs.value }}
-        
+
       - name: Push helm package
         run: helm push $(ls ./chart/*.tgz| head -1) oci://ghcr.io/${{ github.repository_owner }}/charts

--- a/.github/workflows/prune.yml
+++ b/.github/workflows/prune.yml
@@ -2,7 +2,7 @@ name: Prune GHCR
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
 
 permissions:
   contents: write
@@ -15,13 +15,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    
       - name: Prune Images
         uses: vlaurin/action-ghcr-prune@v0.5.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          organization: caas-team
-          container: sparrow
+          organization: ${{ github.repository_owner }}
+          container: ${{ github.repository.name }}
           keep-younger-than: 7 # days
           prune-untagged: true
           prune-tags-regexes: |
@@ -31,8 +30,8 @@ jobs:
         uses: vlaurin/action-ghcr-prune@v0.5.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          organization: caas-team
-          container: charts/sparrow
+          organization: ${{ github.repository_owner }}
+          container: charts/${{ github.repository.name }}
           keep-younger-than: 7 # days
           prune-untagged: true
           prune-tags-regexes: |

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -32,8 +32,8 @@ linters-settings:
     min-complexity: 15
   gofmt:
     rewrite-rules:
-      - pattern: 'interface{}'
-        replacement: 'any'
+      - pattern: "interface{}"
+        replacement: "any"
   goimports:
     local-prefixes: github.com/golangci/golangci-lint
   gomnd:
@@ -44,10 +44,10 @@ linters-settings:
       - condition
       - return
     ignored-numbers:
-      - '0'
-      - '1'
-      - '2'
-      - '3'
+      - "0"
+      - "1"
+      - "2"
+      - "3"
     ignored-functions:
       - strings.SplitN
 
@@ -132,6 +132,7 @@ issues:
     - path: _test\.go
       linters:
         - gomnd
+        - revive
 
     - path: pkg/golinters/errcheck.go
       text: "SA1019: errCfg.Exclude is deprecated: use ExcludeFunctions instead"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
       - id: golangci-lint-repo-mod
         args: [ --config, .golangci.yaml, --, --fix ]
   - repo: https://github.com/norwoodj/helm-docs
-    rev: "v1.12.0"
+    rev: v1.13.0
     hooks:
       - id: helm-docs
         args:

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -63,7 +63,7 @@ func NewCmdRun() *cobra.Command {
 
 // run is the entry point to start the sparrow
 func run() func(cmd *cobra.Command, args []string) error {
-	return func(cmd *cobra.Command, args []string) error {
+	return func(_ *cobra.Command, _ []string) error {
 		cfg := &config.Config{}
 		err := viper.Unmarshal(cfg)
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/caas-team/sparrow
 
-go 1.21
+go 1.22
 
 require (
 	github.com/getkin/kin-openapi v0.120.0

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -152,7 +152,7 @@ func (a *api) registerDefaultRoute(route Route) (err error) {
 func okHandler(ctx context.Context) http.Handler {
 	log := logger.FromContext(ctx)
 
-	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, err := w.Write([]byte("ok"))
 		if err != nil {

--- a/scripts/gen-docs/gen-docs.go
+++ b/scripts/gen-docs/gen-docs.go
@@ -66,7 +66,7 @@ func NewCmdGenDocs() *cobra.Command {
 func runGenDocs(path *string) func(cmd *cobra.Command, args []string) error {
 	c := sparrowcmd.BuildCmd("")
 	c.DisableAutoGenTag = true
-	return func(cmd *cobra.Command, args []string) error {
+	return func(_ *cobra.Command, _ []string) error {
 		if err := doc.GenMarkdownTree(c, *path); err != nil {
 			return fmt.Errorf("failed to generate docs: %w", err)
 		}


### PR DESCRIPTION
## Motivation

I've updated my local external dependencies and suddenly my pre-commit hooks failed.

I saw that as opportunity to also bump the go version and do some general housekeeping of the repository 🙂 

## Changes

- Bumped go v1.22
- Bumped helm-docs v1.13.0
- Ignoring test files for revive linter
- Resolved revive lint errors
- Formatted and cleaned up workflows
- Made workflows more generic 
  - Ref: https://docs.github.com/en/actions/learn-github-actions/variables, https://stackoverflow.com/a/58474340
- Adjusted PR template

For additional information look at the commits.