### PR TITLE
fix/manager-timers

### DIFF
--- a/pkg/sparrow/gitlab/test/mockclient.go
+++ b/pkg/sparrow/gitlab/test/mockclient.go
@@ -35,15 +35,15 @@ type MockClient struct {
 	putFileErr     error
 	postFileErr    error
 	deleteFileErr  error
-	putFileCalled  bool
-	postFileCalled bool
+	putFileCalled  int
+	postFileCalled int
 }
 
 func (m *MockClient) PutFile(ctx context.Context, _ gitlab.File) error { //nolint: gocritic // irrelevant
 	log := logger.FromContext(ctx)
 	log.Info("MockPutFile called", "err", m.putFileErr)
 	m.mu.Lock()
-	m.putFileCalled = true
+	m.putFileCalled++
 	m.mu.Unlock()
 	return m.putFileErr
 }
@@ -52,7 +52,7 @@ func (m *MockClient) PostFile(ctx context.Context, _ gitlab.File) error { //noli
 	log := logger.FromContext(ctx)
 	log.Info("MockPostFile called", "err", m.postFileErr)
 	m.mu.Lock()
-	m.postFileCalled = true
+	m.postFileCalled++
 	m.mu.Unlock()
 	return m.postFileErr
 }
@@ -91,10 +91,20 @@ func (m *MockClient) SetDeleteFileErr(err error) {
 
 // PutFileCalled returns true if PutFile was called
 func (m *MockClient) PutFileCalled() bool {
-	return m.putFileCalled
+	return m.putFileCalled != 0
 }
 
 func (m *MockClient) PostFileCalled() bool {
+	return m.postFileCalled != 0
+}
+
+// PutFileCount returns the number of times PutFile was called
+func (m *MockClient) PutFileCount() int {
+	return m.putFileCalled
+}
+
+// PostFileCount returns the number of times PostFile was called
+func (m *MockClient) PostFileCount() int {
 	return m.postFileCalled
 }
 

--- a/pkg/sparrow/targets/gitlab.go
+++ b/pkg/sparrow/targets/gitlab.go
@@ -133,7 +133,7 @@ func (t *gitlabTargetManager) Shutdown(ctx context.Context) error {
 	ctxS, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 	defer cancel()
 
-	if t.Registered() {
+	if t.registered {
 		f := gitlab.File{
 			Branch:        "main",
 			AuthorEmail:   fmt.Sprintf("%s@sparrow", t.name),
@@ -199,7 +199,7 @@ func (t *gitlabTargetManager) update(ctx context.Context) error {
 
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	if !t.Registered() {
+	if !t.registered {
 		log.Debug("Not registered as global target, no update done.")
 		return nil
 	}
@@ -237,7 +237,7 @@ func (t *gitlabTargetManager) refreshTargets(ctx context.Context) error {
 
 	// filter unhealthy targets - this may be removed in the future
 	for _, target := range targets {
-		if !t.Registered() && target.Url == fmt.Sprintf("https://%s", t.name) {
+		if !t.registered && target.Url == fmt.Sprintf("https://%s", t.name) {
 			log.Debug("Found self as global target", "lastSeenMin", time.Since(target.LastSeen).Minutes())
 			t.registered = true
 		}
@@ -257,11 +257,6 @@ func (t *gitlabTargetManager) refreshTargets(ctx context.Context) error {
 	t.targets = healthyTargets
 	log.Debug("Updated global targets", "targets", len(t.targets))
 	return nil
-}
-
-// Registered returns whether the instance is registered as a global target
-func (t *gitlabTargetManager) Registered() bool {
-	return t.registered
 }
 
 // startTimer creates a new timer with the given duration.

--- a/pkg/sparrow/targets/gitlab.go
+++ b/pkg/sparrow/targets/gitlab.go
@@ -97,16 +97,19 @@ func (t *gitlabTargetManager) Reconcile(ctx context.Context) error {
 			if err != nil {
 				log.Warn("Failed to get global targets", "error", err)
 			}
+			checkTimer.Reset(t.cfg.CheckInterval)
 		case <-registrationTimer.C:
 			err := t.register(ctx)
 			if err != nil {
 				log.Warn("Failed to register self as global target", "error", err)
 			}
+			registrationTimer.Reset(t.cfg.RegistrationInterval)
 		case <-updateTimer.C:
 			err := t.update(ctx)
 			if err != nil {
 				log.Warn("Failed to update registration", "error", err)
 			}
+			updateTimer.Reset(t.cfg.UpdateInterval)
 		}
 	}
 }
@@ -159,10 +162,15 @@ func (t *gitlabTargetManager) Shutdown(ctx context.Context) error {
 // in the gitlab repository
 func (t *gitlabTargetManager) register(ctx context.Context) error {
 	log := logger.FromContext(ctx)
-	log.Debug("Registering as global target")
-
 	t.mu.Lock()
 	defer t.mu.Unlock()
+
+	if t.registered {
+		log.Debug("Already registered as global target")
+		return nil
+	}
+
+	log.Debug("Registering as global target")
 	f := gitlab.File{
 		Branch:        "main",
 		AuthorEmail:   fmt.Sprintf("%s@sparrow", t.name),
@@ -191,25 +199,26 @@ func (t *gitlabTargetManager) update(ctx context.Context) error {
 
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	f := gitlab.File{
-		Branch:      "main",
-		AuthorEmail: fmt.Sprintf("%s@sparrow", t.name),
-		AuthorName:  t.name,
-		Content:     checks.GlobalTarget{Url: fmt.Sprintf("https://%s", t.name), LastSeen: time.Now().UTC()},
-	}
-	f.SetFileName(fmt.Sprintf("%s.json", t.name))
-
-	if t.Registered() {
-		f.CommitMessage = "Updated registration"
-		err := t.gitlab.PutFile(ctx, f)
-		if err != nil {
-			log.Error("Failed to update registration", "error", err)
-			return err
-		}
-		log.Debug("Successfully updated registration")
+	if !t.Registered() {
+		log.Debug("Not registered as global target, no update done.")
 		return nil
 	}
 
+	f := gitlab.File{
+		Branch:        "main",
+		AuthorEmail:   fmt.Sprintf("%s@sparrow", t.name),
+		AuthorName:    t.name,
+		CommitMessage: "Updated registration",
+		Content:       checks.GlobalTarget{Url: fmt.Sprintf("https://%s", t.name), LastSeen: time.Now().UTC()},
+	}
+	f.SetFileName(fmt.Sprintf("%s.json", t.name))
+
+	err := t.gitlab.PutFile(ctx, f)
+	if err != nil {
+		log.Error("Failed to update registration", "error", err)
+		return err
+	}
+	log.Debug("Successfully updated registration")
 	return nil
 }
 

--- a/pkg/sparrow/targets/gitlab_test.go
+++ b/pkg/sparrow/targets/gitlab_test.go
@@ -126,8 +126,8 @@ func Test_gitlabTargetManager_refreshTargets(t *testing.T) {
 				t.Fatalf("refreshTargets() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
-			if gtm.Registered() != tt.expectedRegisteredAfter {
-				t.Fatalf("expected registered to be %v, got %v", tt.expectedRegisteredAfter, gtm.Registered())
+			if gtm.registered != tt.expectedRegisteredAfter {
+				t.Fatalf("expected registered to be %v, got %v", tt.expectedRegisteredAfter, gtm.registered)
 			}
 		})
 	}
@@ -198,8 +198,8 @@ func Test_gitlabTargetManager_refreshTargets_No_Threshold(t *testing.T) {
 				t.Fatalf("refreshTargets() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
-			if gtm.Registered() != tt.expectedRegisteredAfter {
-				t.Fatalf("expected registered to be %v, got %v", tt.expectedRegisteredAfter, gtm.Registered())
+			if gtm.registered != tt.expectedRegisteredAfter {
+				t.Fatalf("expected registered to be %v, got %v", tt.expectedRegisteredAfter, gtm.registered)
 			}
 		})
 	}
@@ -310,7 +310,7 @@ func Test_gitlabTargetManager_register(t *testing.T) {
 			}
 
 			if !tt.wantErr {
-				if !gtm.Registered() {
+				if !gtm.registered {
 					t.Fatalf("register() did not register the instance")
 				}
 			}
@@ -399,7 +399,7 @@ func Test_gitlabTargetManager_Reconcile_success(t *testing.T) {
 			}
 
 			gtm.mu.Lock()
-			if !gtm.Registered() {
+			if !gtm.registered {
 				t.Fatalf("Reconcile() did not register")
 			}
 			gtm.mu.Unlock()
@@ -443,7 +443,7 @@ func Test_gitlabTargetManager_Reconcile_Registration_Update(t *testing.T) {
 	time.Sleep(gtm.cfg.UpdateInterval * 3)
 
 	gtm.mu.Lock()
-	if !gtm.Registered() {
+	if !gtm.registered {
 		t.Fatalf("Reconcile() should be registered")
 	}
 	gtm.mu.Unlock()
@@ -459,7 +459,7 @@ func Test_gitlabTargetManager_Reconcile_Registration_Update(t *testing.T) {
 	}
 
 	gtm.mu.Lock()
-	if !gtm.Registered() {
+	if !gtm.registered {
 		t.Fatalf("Reconcile() should have registered the sparrow")
 	}
 	gtm.mu.Unlock()
@@ -517,11 +517,11 @@ func Test_gitlabTargetManager_Reconcile_failure(t *testing.T) {
 			time.Sleep(time.Millisecond * 300)
 
 			gtm.mu.Lock()
-			if tt.postErr != nil && gtm.Registered() {
+			if tt.postErr != nil && gtm.registered {
 				t.Fatalf("Reconcile() should not have registered")
 			}
 
-			if tt.putError != nil && !gtm.Registered() {
+			if tt.putError != nil && !gtm.registered {
 				t.Fatalf("Reconcile() should still be registered")
 			}
 			gtm.mu.Unlock()
@@ -563,7 +563,7 @@ func Test_gitlabTargetManager_Reconcile_Context_Canceled(t *testing.T) {
 	time.Sleep(time.Millisecond * 250)
 
 	gtm.mu.Lock()
-	if !gtm.Registered() {
+	if !gtm.registered {
 		t.Fatalf("Reconcile() should still be registered")
 	}
 	gtm.mu.Unlock()
@@ -601,7 +601,7 @@ func Test_gitlabTargetManager_Reconcile_Context_Done(t *testing.T) {
 	time.Sleep(time.Millisecond * 15)
 
 	gtm.mu.Lock()
-	if gtm.Registered() {
+	if gtm.registered {
 		t.Fatalf("Reconcile() should not be registered")
 	}
 	gtm.mu.Unlock()
@@ -643,7 +643,7 @@ func Test_gitlabTargetManager_Reconcile_Shutdown(t *testing.T) {
 	}
 
 	gtm.mu.Lock()
-	if gtm.Registered() {
+	if gtm.registered {
 		t.Fatalf("Reconcile() should not be registered")
 	}
 	gtm.mu.Unlock()
@@ -688,7 +688,7 @@ func Test_gitlabTargetManager_Reconcile_Shutdown_Fail_Unregister(t *testing.T) {
 
 	gtm.mu.Lock()
 	// instance should still be registered because the unregister failed
-	if !gtm.Registered() {
+	if !gtm.registered {
 		t.Fatalf("Reconcile() should still be registered")
 	}
 	gtm.mu.Unlock()
@@ -726,7 +726,7 @@ func Test_gitlabTargetManager_Reconcile_No_Registration(t *testing.T) {
 	time.Sleep(time.Millisecond * 250)
 
 	gtm.mu.Lock()
-	if gtm.Registered() {
+	if gtm.registered {
 		t.Fatalf("Reconcile() should not be registered")
 	}
 	gtm.mu.Unlock()
@@ -764,7 +764,7 @@ func Test_gitlabTargetManager_Reconcile_No_Update(t *testing.T) {
 	time.Sleep(time.Millisecond * 250)
 
 	gtm.mu.Lock()
-	if !gtm.Registered() {
+	if !gtm.registered {
 		t.Fatalf("Reconcile() should be registered")
 	}
 	gtm.mu.Unlock()
@@ -807,7 +807,7 @@ func Test_gitlabTargetManager_Reconcile_No_Registration_No_Update(t *testing.T) 
 	time.Sleep(time.Millisecond * 250)
 
 	gtm.mu.Lock()
-	if gtm.Registered() {
+	if gtm.registered {
 		t.Fatalf("Reconcile() should not be registered")
 	}
 	gtm.mu.Unlock()


### PR DESCRIPTION
## Motivation

The target manager is broken and only runs once.

## Changes

- Reverted changes
- Added new mock test and made old ones more robust
- Fixed two bugs, where register and update would be called indefinetely, because of not checking for registration first. 

For additional information look at the commits.

## Tests done

Run the code locally, works as expected. Registration, update and getting targets worked as expected.

- [x] Unit tests succeeded
- [x] E2E tests succeeded

## TODO

- [x] I've assigned this PR to myself
- [x] I've labeled this PR correctly

<!-- Add open ToDo's to this checklist -->