### PR TITLE
refactor: startup config validation

### DIFF
--- a/pkg/config/errors.go
+++ b/pkg/config/errors.go
@@ -1,0 +1,34 @@
+// sparrow
+// (C) 2024, Deutsche Telekom IT GmbH
+//
+// Deutsche Telekom IT GmbH and all other contributors /
+// copyright owners license this file to you under the Apache
+// License, Version 2.0 (the "License"); you may not use this
+// file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package config
+
+import "errors"
+
+var (
+	// ErrInvalidSparrowName is returned when the sparrow name is invalid
+	ErrInvalidSparrowName = errors.New("invalid sparrow name")
+	// ErrInvalidLoaderInterval is returned when the loader interval is invalid
+	ErrInvalidLoaderInterval = errors.New("invalid loader interval")
+	// ErrInvalidLoaderHttpURL is returned when the loader http url is invalid
+	ErrInvalidLoaderHttpURL = errors.New("invalid loader http url")
+	// ErrInvalidLoaderHttpRetryCount is returned when the loader http retry count is invalid
+	ErrInvalidLoaderHttpRetryCount = errors.New("invalid loader http retry count")
+	// ErrInvalidLoaderFilePath is returned when the loader file path is invalid
+	ErrInvalidLoaderFilePath = errors.New("invalid loader file path")
+)

--- a/pkg/config/validate_test.go
+++ b/pkg/config/validate_test.go
@@ -24,24 +24,20 @@ import (
 	"time"
 
 	"github.com/caas-team/sparrow/internal/helper"
-	"github.com/caas-team/sparrow/internal/logger"
 )
 
 func TestConfig_Validate(t *testing.T) {
-	ctx, cancel := logger.NewContextWithLogger(context.Background())
-	defer cancel()
+	ctx := context.Background()
 
-	type fields struct {
-		Loader LoaderConfig
-	}
 	tests := []struct {
 		name    string
-		fields  fields
+		config  Config
 		wantErr bool
 	}{
 		{
 			name: "config ok",
-			fields: fields{
+			config: Config{
+				SparrowName: "sparrow.com",
 				Loader: LoaderConfig{
 					Type: "http",
 					Http: HttpLoaderConfig{
@@ -55,11 +51,13 @@ func TestConfig_Validate(t *testing.T) {
 					Interval: time.Second,
 				},
 			},
+
 			wantErr: false,
 		},
 		{
-			name: "url missing",
-			fields: fields{
+			name: "loader - url missing",
+			config: Config{
+				SparrowName: "sparrow.com",
 				Loader: LoaderConfig{
 					Type: "http",
 					Http: HttpLoaderConfig{
@@ -73,11 +71,13 @@ func TestConfig_Validate(t *testing.T) {
 					Interval: time.Second,
 				},
 			},
+
 			wantErr: true,
 		},
 		{
-			name: "url malformed",
-			fields: fields{
+			name: "loader - url malformed",
+			config: Config{
+				SparrowName: "sparrow.com",
 				Loader: LoaderConfig{
 					Type: "http",
 					Http: HttpLoaderConfig{
@@ -94,8 +94,9 @@ func TestConfig_Validate(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "retry count to high",
-			fields: fields{
+			name: "loader - retry count to high",
+			config: Config{
+				SparrowName: "sparrow.com",
 				Loader: LoaderConfig{
 					Type: "http",
 					Http: HttpLoaderConfig{
@@ -112,8 +113,9 @@ func TestConfig_Validate(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "file path malformed",
-			fields: fields{
+			name: "loader - file path malformed",
+			config: Config{
+				SparrowName: "sparrow.com",
 				Loader: LoaderConfig{
 					Type: "file",
 					File: FileLoaderConfig{
@@ -127,11 +129,7 @@ func TestConfig_Validate(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := &Config{
-				SparrowName: "cool-dns-name.org",
-				Loader:      tt.fields.Loader,
-			}
-			if err := c.Validate(ctx); (err != nil) != tt.wantErr {
+			if err := tt.config.Validate(ctx); (err != nil) != tt.wantErr {
 				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/pkg/sparrow/targets/errors.go
+++ b/pkg/sparrow/targets/errors.go
@@ -20,14 +20,13 @@ package targets
 
 import "errors"
 
-// ErrInvalidCheckInterval is returned when the check interval is invalid
-var ErrInvalidCheckInterval = errors.New("invalid check interval")
-
-// ErrInvalidRegistrationInterval is returned when the registration interval is invalid
-var ErrInvalidRegistrationInterval = errors.New("invalid registration interval")
-
-// ErrInvalidUnhealthyThreshold is returned when the unhealthy threshold is invalid
-var ErrInvalidUnhealthyThreshold = errors.New("invalid unhealthy threshold")
-
-// ErrInvalidUpdateInterval is returned when the update interval is invalid
-var ErrInvalidUpdateInterval = errors.New("invalid update interval")
+var (
+	// ErrInvalidCheckInterval is returned when the check interval is invalid
+	ErrInvalidCheckInterval = errors.New("invalid check interval")
+	// ErrInvalidRegistrationInterval is returned when the registration interval is invalid
+	ErrInvalidRegistrationInterval = errors.New("invalid registration interval")
+	// ErrInvalidUnhealthyThreshold is returned when the unhealthy threshold is invalid
+	ErrInvalidUnhealthyThreshold = errors.New("invalid unhealthy threshold")
+	// ErrInvalidUpdateInterval is returned when the update interval is invalid
+	ErrInvalidUpdateInterval = errors.New("invalid update interval")
+)

--- a/pkg/sparrow/targets/targetmanager.go
+++ b/pkg/sparrow/targets/targetmanager.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/caas-team/sparrow/internal/logger"
 	"github.com/caas-team/sparrow/pkg/checks"
 )
 
@@ -54,22 +55,30 @@ type Config struct {
 	UnhealthyThreshold time.Duration `yaml:"unhealthyThreshold" mapstructure:"unhealthyThreshold"`
 }
 
+// TargetManagerConfig is the configuration for the target manager
 type TargetManagerConfig struct {
+	// Config is the general configuration of the target manager
 	Config `yaml:",inline" mapstructure:",squash"`
+	// Gitlab is the configuration for the Gitlab target manager
 	Gitlab GitlabTargetManagerConfig `yaml:"gitlab" mapstructure:"gitlab"`
 }
 
-func (tmc *Config) Validate() error {
-	if tmc.CheckInterval <= 0 {
+func (c *TargetManagerConfig) Validate(ctx context.Context) error {
+	log := logger.FromContext(ctx)
+	if c.CheckInterval <= 0 {
+		log.Error("The check interval should be above 0", "interval", c.CheckInterval)
 		return ErrInvalidCheckInterval
 	}
-	if tmc.RegistrationInterval < 0 {
+	if c.RegistrationInterval < 0 {
+		log.Error("The registration interval should be equal or above 0", "interval", c.RegistrationInterval)
 		return ErrInvalidRegistrationInterval
 	}
-	if tmc.UnhealthyThreshold < 0 {
+	if c.UnhealthyThreshold < 0 {
+		log.Error("The unhealthy threshold should be equal or above 0", "threshold", c.UnhealthyThreshold)
 		return ErrInvalidUnhealthyThreshold
 	}
-	if tmc.UpdateInterval < 0 {
+	if c.UpdateInterval < 0 {
+		log.Error("The update interval should be equal or above 0", "interval", c.UpdateInterval)
 		return ErrInvalidUpdateInterval
 	}
 	return nil

--- a/pkg/sparrow/targets/targetmanager_test.go
+++ b/pkg/sparrow/targets/targetmanager_test.go
@@ -19,6 +19,7 @@
 package targets
 
 import (
+	"context"
 	"testing"
 	"time"
 )
@@ -26,7 +27,7 @@ import (
 func TestTargetManagerConfig_Validate(t *testing.T) {
 	tests := []struct {
 		name    string
-		cfg     Config
+		cfg     TargetManagerConfig
 		wantErr bool
 	}{
 		{
@@ -35,46 +36,54 @@ func TestTargetManagerConfig_Validate(t *testing.T) {
 		},
 		{
 			name: "valid config - non-zero values",
-			cfg: Config{
-				UnhealthyThreshold:   1 * time.Second,
-				CheckInterval:        1 * time.Second,
-				RegistrationInterval: 1 * time.Second,
-				UpdateInterval:       1 * time.Second,
+			cfg: TargetManagerConfig{
+				Config: Config{
+					UnhealthyThreshold:   1 * time.Second,
+					CheckInterval:        1 * time.Second,
+					RegistrationInterval: 1 * time.Second,
+					UpdateInterval:       1 * time.Second,
+				},
 			},
 		},
 		{
 			name: "valid config - zero values",
-			cfg: Config{
-				UnhealthyThreshold:   0,
-				CheckInterval:        1 * time.Second,
-				RegistrationInterval: 0,
-				UpdateInterval:       0,
+			cfg: TargetManagerConfig{
+				Config: Config{
+					UnhealthyThreshold:   0,
+					CheckInterval:        1 * time.Second,
+					RegistrationInterval: 0,
+					UpdateInterval:       0,
+				},
 			},
 		},
 		{
 			name: "invalid config - zero check interval",
-			cfg: Config{
-				UnhealthyThreshold:   1 * time.Second,
-				CheckInterval:        0,
-				RegistrationInterval: 1 * time.Second,
-				UpdateInterval:       1 * time.Second,
+			cfg: TargetManagerConfig{
+				Config: Config{
+					UnhealthyThreshold:   1 * time.Second,
+					CheckInterval:        0,
+					RegistrationInterval: 1 * time.Second,
+					UpdateInterval:       1 * time.Second,
+				},
 			},
 			wantErr: true,
 		},
 		{
 			name: "invalid config - negative values",
-			cfg: Config{
-				UnhealthyThreshold:   -1 * time.Second,
-				CheckInterval:        1 * time.Second,
-				RegistrationInterval: 1 * time.Second,
-				UpdateInterval:       1 * time.Second,
+			cfg: TargetManagerConfig{
+				Config: Config{
+					UnhealthyThreshold:   -1 * time.Second,
+					CheckInterval:        1 * time.Second,
+					RegistrationInterval: 1 * time.Second,
+					UpdateInterval:       1 * time.Second,
+				},
 			},
 			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := tt.cfg.Validate(); (err != nil) != tt.wantErr {
+			if err := tt.cfg.Validate(context.Background()); (err != nil) != tt.wantErr {
 				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})


### PR DESCRIPTION
## Motivation

Currently the target manager config has a `Validate` method that is never consumed.

This PR is part of #66 which will implement another target manager type and therefore needs more target manager config validation. That's also when I noticed that the target manager config is never validated. 😄 

## Changes

I've refactored the startup config validation so every startup config component has its own `Validate()` method.

* fix: validate target manager config
* refactor: split config validation in smaller methods
* chore: use errors instead of ok booleans

For additional information look at the commits.

## Tests done

I've adjusted the existing unit tests.

- [x] Unit tests succeeded
- [x] E2E tests succeeded

## TODO

- [x] I've assigned this PR to myself
- [x] I've labeled this PR correctly

<!-- Add open ToDo's to this checklist -->