### PR TITLE
Remove unused errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,12 +12,9 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
-require github.com/google/go-cmp v0.6.0 // indirect
+require github.com/google/go-cmp v0.6.0
 
-require (
-	github.com/aeden/traceroute v0.0.0-20210211061815-03f5f7cb7908
-	github.com/google/go-cmp v0.6.0
-)
+require github.com/aeden/traceroute v0.0.0-20210211061815-03f5f7cb7908
 
 require github.com/mitchellh/mapstructure v1.5.0 // indirect
 

--- a/pkg/checks/base.go
+++ b/pkg/checks/base.go
@@ -43,7 +43,7 @@ type Check interface {
 	// Returning a non-nil error will cause the shutdown of the check.
 	Run(ctx context.Context, cResult chan ResultDTO) error
 	// Shutdown is called once when the check is unregistered or sparrow shuts down
-	Shutdown(ctx context.Context) error
+	Shutdown()
 	// SetConfig is called once when the check is registered
 	// This is also called while the check is running, if the remote config is updated
 	// This should return an error if the config is invalid

--- a/pkg/checks/base_moq.go
+++ b/pkg/checks/base_moq.go
@@ -38,7 +38,7 @@ var _ Check = &CheckMock{}
 //			SetConfigFunc: func(config Runtime) error {
 //				panic("mock out the SetConfig method")
 //			},
-//			ShutdownFunc: func(ctx context.Context) error {
+//			ShutdownFunc: func()  {
 //				panic("mock out the Shutdown method")
 //			},
 //		}
@@ -67,7 +67,7 @@ type CheckMock struct {
 	SetConfigFunc func(config Runtime) error
 
 	// ShutdownFunc mocks the Shutdown method.
-	ShutdownFunc func(ctx context.Context) error
+	ShutdownFunc func()
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -97,8 +97,6 @@ type CheckMock struct {
 		}
 		// Shutdown holds details about calls to the Shutdown method.
 		Shutdown []struct {
-			// Ctx is the ctx argument value.
-			Ctx context.Context
 		}
 	}
 	lockGetConfig           sync.RWMutex
@@ -287,19 +285,16 @@ func (mock *CheckMock) SetConfigCalls() []struct {
 }
 
 // Shutdown calls ShutdownFunc.
-func (mock *CheckMock) Shutdown(ctx context.Context) error {
+func (mock *CheckMock) Shutdown() {
 	if mock.ShutdownFunc == nil {
 		panic("CheckMock.ShutdownFunc: method is nil but Check.Shutdown was just called")
 	}
 	callInfo := struct {
-		Ctx context.Context
-	}{
-		Ctx: ctx,
-	}
+	}{}
 	mock.lockShutdown.Lock()
 	mock.calls.Shutdown = append(mock.calls.Shutdown, callInfo)
 	mock.lockShutdown.Unlock()
-	return mock.ShutdownFunc(ctx)
+	mock.ShutdownFunc()
 }
 
 // ShutdownCalls gets all the calls that were made to Shutdown.
@@ -307,10 +302,8 @@ func (mock *CheckMock) Shutdown(ctx context.Context) error {
 //
 //	len(mockedCheck.ShutdownCalls())
 func (mock *CheckMock) ShutdownCalls() []struct {
-	Ctx context.Context
 } {
 	var calls []struct {
-		Ctx context.Context
 	}
 	mock.lockShutdown.RLock()
 	calls = mock.calls.Shutdown

--- a/pkg/checks/dns/dns.go
+++ b/pkg/checks/dns/dns.go
@@ -107,11 +107,9 @@ func (d *DNS) Run(ctx context.Context, cResult chan checks.ResultDTO) error {
 	}
 }
 
-func (d *DNS) Shutdown(_ context.Context) error {
+func (d *DNS) Shutdown() {
 	d.DoneChan <- struct{}{}
 	close(d.DoneChan)
-
-	return nil
 }
 
 func (d *DNS) SetConfig(cfg checks.Runtime) error {

--- a/pkg/checks/dns/dns_test.go
+++ b/pkg/checks/dns/dns_test.go
@@ -185,11 +185,7 @@ func TestDNS_Run(t *testing.T) {
 				}
 			}()
 			defer func() {
-				err := c.Shutdown(ctx)
-				if err != nil {
-					t.Errorf("DNS.Shutdown() error = %v", err)
-					return
-				}
+				c.Shutdown()
 			}()
 
 			r := <-cResult
@@ -252,10 +248,7 @@ func TestDNS_Shutdown(t *testing.T) {
 			DoneChan: cDone,
 		},
 	}
-	err := c.Shutdown(context.Background())
-	if err != nil {
-		t.Errorf("Shutdown() error = %v", err)
-	}
+	c.Shutdown()
 
 	_, ok := <-cDone
 	if !ok {

--- a/pkg/checks/health/health.go
+++ b/pkg/checks/health/health.go
@@ -101,11 +101,9 @@ func (h *Health) Run(ctx context.Context, cResult chan checks.ResultDTO) error {
 }
 
 // Shutdown is called once when the check is unregistered or sparrow shuts down
-func (h *Health) Shutdown(_ context.Context) error {
+func (h *Health) Shutdown() {
 	h.DoneChan <- struct{}{}
 	close(h.DoneChan)
-
-	return nil
 }
 
 // SetConfig sets the configuration for the health check

--- a/pkg/checks/health/health_test.go
+++ b/pkg/checks/health/health_test.go
@@ -255,10 +255,7 @@ func TestHealth_Shutdown(t *testing.T) {
 			DoneChan: cDone,
 		},
 	}
-	err := c.Shutdown(context.Background())
-	if err != nil {
-		t.Errorf("Shutdown() error = %v", err)
-	}
+	c.Shutdown()
 
 	if _, ok := <-cDone; !ok {
 		t.Error("Channel should be done")
@@ -269,10 +266,7 @@ func TestHealth_Shutdown(t *testing.T) {
 	}, "Channel is closed, should panic")
 
 	hc := NewCheck()
-	err = hc.Shutdown(context.Background())
-	if err != nil {
-		t.Errorf("Shutdown() error = %v", err)
-	}
+	hc.Shutdown()
 
 	_, ok := <-hc.(*Health).DoneChan
 	if !ok {

--- a/pkg/checks/latency/latency.go
+++ b/pkg/checks/latency/latency.go
@@ -105,11 +105,9 @@ func (l *Latency) Run(ctx context.Context, cResult chan checks.ResultDTO) error 
 	}
 }
 
-func (l *Latency) Shutdown(_ context.Context) error {
+func (l *Latency) Shutdown() {
 	l.DoneChan <- struct{}{}
 	close(l.DoneChan)
-
-	return nil
 }
 
 // SetConfig sets the configuration for the latency check

--- a/pkg/checks/latency/latency_test.go
+++ b/pkg/checks/latency/latency_test.go
@@ -146,11 +146,7 @@ func TestLatency_Run(t *testing.T) {
 				}
 			}()
 			defer func() {
-				err := c.Shutdown(tt.ctx)
-				if err != nil {
-					t.Errorf("Latency.Shutdown() error = %v", err)
-					return
-				}
+				c.Shutdown()
 			}()
 
 			res := <-cResult
@@ -316,10 +312,7 @@ func TestLatency_Shutdown(t *testing.T) {
 			DoneChan: cDone,
 		},
 	}
-	err := c.Shutdown(context.Background())
-	if err != nil {
-		t.Errorf("Shutdown() error = %v", err)
-	}
+	c.Shutdown()
 
 	_, ok := <-cDone
 	if !ok {

--- a/pkg/checks/traceroute/traceroute.go
+++ b/pkg/checks/traceroute/traceroute.go
@@ -160,10 +160,9 @@ func (tr *Traceroute) check(ctx context.Context) map[string]result {
 }
 
 // Shutdown is called once when the check is unregistered or sparrow shuts down
-func (tr *Traceroute) Shutdown(_ context.Context) error {
+func (tr *Traceroute) Shutdown() {
 	tr.DoneChan <- struct{}{}
 	close(tr.DoneChan)
-	return nil
 }
 
 // SetConfig is called once when the check is registered

--- a/pkg/sparrow/controller.go
+++ b/pkg/sparrow/controller.go
@@ -120,9 +120,6 @@ func (cc *ChecksController) Reconcile(ctx context.Context, cfg runtime.Config) {
 	// Unregister checks not in the new config
 	for _, c := range unregList {
 		cc.UnregisterCheck(ctx, c)
-		if err != nil {
-			log.ErrorContext(ctx, "Failed to unregister check", "check", c.Name(), "error", err)
-		}
 	}
 
 	// Register new checks

--- a/pkg/sparrow/controller.go
+++ b/pkg/sparrow/controller.go
@@ -177,11 +177,7 @@ func (cc *ChecksController) UnregisterCheck(ctx context.Context, check checks.Ch
 		}
 	}
 
-	err := check.Shutdown(ctx)
-	if err != nil {
-		log.ErrorContext(ctx, "Failed to shutdown check", "error", err)
-		return err
-	}
+	check.Shutdown()
 
 	cc.checks.Delete(check)
 	return nil

--- a/pkg/sparrow/controller_test.go
+++ b/pkg/sparrow/controller_test.go
@@ -50,9 +50,7 @@ func TestRun_CheckRunError(t *testing.T) {
 		GetMetricCollectorsFunc: func() []prometheus.Collector {
 			return []prometheus.Collector{}
 		},
-		ShutdownFunc: func(ctx context.Context) error {
-			return nil
-		},
+		ShutdownFunc: func() {},
 	}
 
 	err := cc.RegisterCheck(ctx, mockCheck)
@@ -301,35 +299,6 @@ func TestChecksController_UnregisterCheck(t *testing.T) {
 			},
 			check:   health.NewCheck(),
 			wantErr: false,
-		},
-		{
-			name: "error during check shutdown",
-			setup: func(t *testing.T) *ChecksController {
-				cc := NewChecksController(db.NewInMemory(), NewMetrics())
-				check := &checks.CheckMock{
-					NameFunc:                func() string { return "check" },
-					GetMetricCollectorsFunc: func() []prometheus.Collector { return []prometheus.Collector{} },
-					RunFunc:                 func(ctx context.Context, cResult chan checks.ResultDTO) error { return nil },
-					ShutdownFunc: func(ctx context.Context) error {
-						return fmt.Errorf("some error")
-					},
-				}
-				err := cc.RegisterCheck(context.Background(), check)
-				if err != nil {
-					t.Fatalf("RegisterCheck() error = %v", err)
-				}
-				return cc
-			},
-			check: &checks.CheckMock{
-				NameFunc: func() string { return "check" },
-				GetMetricCollectorsFunc: func() []prometheus.Collector {
-					return []prometheus.Collector{}
-				},
-				ShutdownFunc: func(ctx context.Context) error {
-					return fmt.Errorf("some error")
-				},
-			},
-			wantErr: true,
 		},
 	}
 

--- a/pkg/sparrow/controller_test.go
+++ b/pkg/sparrow/controller_test.go
@@ -306,10 +306,7 @@ func TestChecksController_UnregisterCheck(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cc := tt.setup(t)
 
-			err := cc.UnregisterCheck(context.Background(), tt.check)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("UnregisterCheck() error = %v, wantErr %v", err, tt.wantErr)
-			}
+			cc.UnregisterCheck(context.Background(), tt.check)
 
 			if !tt.wantErr && len(cc.checks.Iter()) != 0 {
 				t.Errorf("Expected check to be unregistered")

--- a/pkg/sparrow/targets/gitlab.go
+++ b/pkg/sparrow/targets/gitlab.go
@@ -186,7 +186,7 @@ func (t *gitlabTargetManager) register(ctx context.Context) error {
 		return err
 	}
 
-	log.Debug("Successfully registered")
+	log.Info("Successfully registered instance as global target")
 	t.registered = true
 	return nil
 }


### PR DESCRIPTION
## Motivation

Closes #37 - no need to carry corpses around in the codebase.

## Changes

See commits. Removed unused err values and ctx values as well from all shutdown functions of the checks, and updated the checkController's shutdown as well (it was never returing an err).

## Tests done

<!-- Explain what tests you've done and if your tests worked -->

- [x] Unit tests succeeded
- [ ] E2E tests succeeded - not running any as we have none

## TODO

- [x] I've assigned this PR to myself
- [x] I've labeled this PR correctly

<!-- Add open ToDo's to this checklist -->