### PR TITLE
Push to MTR directly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,4 +101,4 @@ jobs:
       - name: Push helm package
         run: |
           helm push $(ls ./chart/*.tgz| head -1) oci://ghcr.io/${{ github.repository_owner }}/charts
-          helm push $(ls ./chart/*.tgz| head -1) oci://mtr.devops.telekom.de/sparrow/charts
+          helm push $(ls ./chart/*.tgz| head -1) oci://mtr.devops.telekom.de/sparrow/chart

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           sarif_file: "trivy-results.sarif"
 
-      - name: GHRC Registry login
+      - name: GHCR login
         uses: docker/login-action@v3
         with:
           registry: ghcr.io

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
       - name: Push snapshot container image
         run: |
           docker push ghcr.io/${{ github.repository }}:${{ steps.version.outputs.value }}
+          docker tag ghcr.io/${{ github.repository }}:${{ steps.version.outputs.value }} mtr.devops.telekom.de/sparrow/sparrow:${{ steps.version.outputs.value }}
           docker push mtr.devops.telekom.de/sparrow/sparrow:${{ steps.version.outputs.value }}
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,4 +101,4 @@ jobs:
       - name: Push helm package
         run: |
           helm push $(ls ./chart/*.tgz| head -1) oci://ghcr.io/${{ github.repository_owner }}/charts
-          helm push $(ls ./chart/*.tgz| head -1) oci://mtr.devops.telekom.de/sparrow/chart
+          helm push $(ls ./chart/*.tgz| head -1) oci://mtr.devops.telekom.de/sparrow/charts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,15 +46,26 @@ jobs:
         with:
           sarif_file: "trivy-results.sarif"
 
-      - name: Registry login
+      - name: GHRC Registry login
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to MTR
+        uses: docker/login-action@v3
+        with:
+          registry: mtr.devops.telekom.de
+          username: ${{ secrets.MTR_USERNAME }}
+          password: ${{ secrets.MTR_PASSWORD }}
+
       - name: Push snapshot container image
-        run: docker push ghcr.io/${{ github.repository }}:${{ steps.version.outputs.value }}
+        run: |
+          docker push ghcr.io/${{ github.repository }}:${{ steps.version.outputs.value }}
+          docker push mtr.devops.telekom.de/sparrow/sparrow:${{ steps.version.outputs.value }}
+
+        
 
   helm:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,6 @@ jobs:
           docker push ghcr.io/${{ github.repository }}:${{ steps.version.outputs.value }}
           docker push mtr.devops.telekom.de/sparrow/sparrow:${{ steps.version.outputs.value }}
 
-        
 
   helm:
     runs-on: ubuntu-latest
@@ -88,7 +87,9 @@ jobs:
         run: echo "value=$(git tag --sort=taggerdate | tail -1 | cut -c 2-)-commit-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Registry login
-        run: helm registry login ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          helm registry login ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
+          helm registry login mtr.devops.telekom.de -u ${{ secrets.MTR_USERNAME }} -p ${{ secrets.MTR_PASSWORD }}
 
       - name: Helm lint
         run: helm lint ./chart
@@ -97,4 +98,6 @@ jobs:
         run: helm package ./chart -d ./chart --version ${{ steps.chartVersion.outputs.value }} --app-version ${{ steps.appVersion.outputs.value }}
 
       - name: Push helm package
-        run: helm push $(ls ./chart/*.tgz| head -1) oci://ghcr.io/${{ github.repository_owner }}/charts
+        run: |
+          helm push $(ls ./chart/*.tgz| head -1) oci://ghcr.io/${{ github.repository_owner }}/charts
+          helm push $(ls ./chart/*.tgz| head -1) oci://mtr.devops.telekom.de/sparrow/charts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,4 +65,4 @@ jobs:
       - name: Push helm package
         run: |
           helm push $(ls ./chart/*.tgz| head -1) oci://ghcr.io/${{ github.repository_owner }}/charts
-          helm push $(ls ./chart/*.tgz| head -1) oci://mtr.devops.telekom.de/sparrow/charts
+          helm push $(ls ./chart/*.tgz| head -1) oci://mtr.devops.telekom.de/sparrow/chart

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,18 @@ jobs:
           go-version-file: go.mod
 
       - uses: docker/login-action@v3
+        name: Login to GHCR
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/login-action@v3
+        name: Login to MTR
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.MTR_USERNAME }}
+          password: ${{ secrets.MTR_PASSWORD }}
 
       - name: Build, push & release
         uses: goreleaser/goreleaser-action@v5
@@ -53,4 +61,6 @@ jobs:
         run: helm package ./chart -d ./chart
         
       - name: Push helm package
-        run: helm push $(ls ./chart/*.tgz| head -1) oci://ghcr.io/${{ github.repository_owner }}/charts
+        run: | 
+          helm push $(ls ./chart/*.tgz| head -1) oci://ghcr.io/${{ github.repository_owner }}/charts
+          helm push $(ls ./chart/*.tgz| head -1) oci://mtr.devops.telekom.de/sparrow/charts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v4
-      
+
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
@@ -33,7 +33,7 @@ jobs:
       - uses: docker/login-action@v3
         name: Login to MTR
         with:
-          registry: ghcr.io
+          registry: mtr.devops.telekom.de
           username: ${{ secrets.MTR_USERNAME }}
           password: ${{ secrets.MTR_PASSWORD }}
 
@@ -50,17 +50,19 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
-      
+
       - name: Registry login
-        run: helm registry login ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          helm registry login ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
+          helm registry login mtr.devops.telekom.de -u ${{ secrets.MTR_USERNAME }} -p ${{ secrets.MTR_PASSWORD }}
 
       - name: Helm lint
         run: helm lint ./chart
-      
+
       - name: Helm package
         run: helm package ./chart -d ./chart
-        
+
       - name: Push helm package
-        run: | 
+        run: |
           helm push $(ls ./chart/*.tgz| head -1) oci://ghcr.io/${{ github.repository_owner }}/charts
           helm push $(ls ./chart/*.tgz| head -1) oci://mtr.devops.telekom.de/sparrow/charts

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,0 @@
-<project version="4">
-  <component name="ProjectRootManager">
-    <output url="file://$PROJECT_DIR$/out" />
-  </component>
-</project>


### PR DESCRIPTION
## Motivation

We don't need to depend to MTR doing its mirroring for the image. We can directly push the image here once build and be done with it.

Mirroring is a deferred process, which hasn't been working lately (at least of the sparrow repository). Switching to a push based approach, given the small volume of traffic on this repository, is the simplest solution to move & test quickly.

## Changes

Changed the CI actions to push the OCI artrifacts to MTR as well.

For additional information look at the commits.

## Tests done

None needed.

## TODO

- [x] I've assigned this PR to myself
- [x] I've labeled this PR correctly
- [x] Add secrets to repository

<!-- Add open ToDo's to this checklist -->