### PR TITLE
Bump chart's appVersion and fix chart repo on release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,4 +65,4 @@ jobs:
       - name: Push helm package
         run: |
           helm push $(ls ./chart/*.tgz| head -1) oci://ghcr.io/${{ github.repository_owner }}/charts
-          helm push $(ls ./chart/*.tgz| head -1) oci://mtr.devops.telekom.de/sparrow/chart
+          helm push $(ls ./chart/*.tgz| head -1) oci://mtr.devops.telekom.de/sparrow/charts

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 keywords:
   - monitoring
 version: 0.0.4
-appVersion: "v0.3.1"
+appVersion: "v0.3.2"
 icon: https://github.com/caas-team/sparrow/blob/main/docs/img/sparrow.png
 sources:
   - https://github.com/caas-team/sparrow

--- a/chart/README.md
+++ b/chart/README.md
@@ -1,6 +1,6 @@
 # sparrow
 
-![Version: 0.0.4](https://img.shields.io/badge/Version-0.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.1](https://img.shields.io/badge/AppVersion-v0.3.1-informational?style=flat-square)
+![Version: 0.0.4](https://img.shields.io/badge/Version-0.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.2](https://img.shields.io/badge/AppVersion-v0.3.2-informational?style=flat-square)
 
 A Helm chart to install Sparrow
 


### PR DESCRIPTION
## Motivation

The appVersion was false and the helm release job was pushing to a wrong repo.

## Changes

See commits.

## Tests done

None, seems pretty straightforward.

## TODO

- [x] I've assigned this PR to myself
- [x] I've labeled this PR correctly

<!-- Add open ToDo's to this checklist -->