### PR TITLE
Feat/https for everyone

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,8 @@ api:
 # Configures the target manager
 # Omitting this section will disable the target manager
 targetManager:
+  # whether to enable the target manager. defaults to false
+  enabled: true
   # Defines which target manager to use.
   type: gitlab
   # The interval for the target reconciliation process
@@ -316,17 +318,18 @@ the `TargetManager` interface. This feature is optional; if the startup configur
 the `targetManager`, it will not be used. When configured, it offers various settings, detailed below, which can be set
 in the startup YAML configuration file as shown in the [example configuration](#example-startup-configuration).
 
-| Type                                 | Description                                                                                  |
-| ------------------------------------ | -------------------------------------------------------------------------------------------- |
-| `targetManager.type`                 | Type of the target manager. Options: `gitlab`                                                |
-| `targetManager.checkInterval`        | Interval for checking new targets.                                                           |
-| `targetManager.unhealthyThreshold`   | Threshold for marking a target as unhealthy. 0 means no cleanup.                             |
-| `targetManager.registrationInterval` | Interval for registering the current sparrow at the target backend. 0 means no registration. |
-| `targetManager.updateInterval`       | Interval for updating the registration of the current sparrow. 0 means no update.            |
-| `targetManager.gitlab.baseUrl`       | Base URL of the GitLab instance.                                                             |
-| `targetManager.gitlab.token`         | Token for authenticating with the GitLab instance.                                           |
-| `targetManager.gitlab.projectId`     | Project ID for the GitLab project used as a remote state backend.                            |
-| `targetManager.scheme`               | Should the target register itself as http or https. Can be `http` or `https`. This needs to be set to `https`, when `api.tls.enabled` == `true`|
+| Type                                 | Description                                                                                                                                     |
+| ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `targetManager.enabled`              | Whether to enable the target manager. Defaults to false                                                                                         |
+| `targetManager.type`                 | Type of the target manager. Options: `gitlab`                                                                                                   |
+| `targetManager.checkInterval`        | Interval for checking new targets.                                                                                                              |
+| `targetManager.unhealthyThreshold`   | Threshold for marking a target as unhealthy. 0 means no cleanup.                                                                                |
+| `targetManager.registrationInterval` | Interval for registering the current sparrow at the target backend. 0 means no registration.                                                    |
+| `targetManager.updateInterval`       | Interval for updating the registration of the current sparrow. 0 means no update.                                                               |
+| `targetManager.gitlab.baseUrl`       | Base URL of the GitLab instance.                                                                                                                |
+| `targetManager.gitlab.token`         | Token for authenticating with the GitLab instance.                                                                                              |
+| `targetManager.gitlab.projectId`     | Project ID for the GitLab project used as a remote state backend.                                                                               |
+| `targetManager.scheme`               | Should the target register itself as http or https. Can be `http` or `https`. This needs to be set to `https`, when `api.tls.enabled` == `true` |
 
 Currently, only one target manager exists: the Gitlab target manager. It uses a gitlab project as the remote state
 backend. The various `sparrow` instances can register themselves as targets in the project.

--- a/README.md
+++ b/README.md
@@ -254,6 +254,8 @@ targetManager:
   # before it is removed from the global target list
   # A duration of 0 means no removal
   unhealthyThreshold: 360m
+  # Scheme defines with which scheme sparrow should register itself (default to http)
+  scheme: http
   # Configuration options for the GitLab target manager
   gitlab:
     # The URL of your GitLab host

--- a/README.md
+++ b/README.md
@@ -226,6 +226,16 @@ loader:
 api:
   # Which address to expose Sparrow's REST API on
   address: :8080
+  # Configures tls for the http server
+  # including prometheus metrics etc
+  tls:
+    # whether to enable tls, default is false
+    enabled: true
+    # path to your x509 certificate
+    certPath: mycert.pem
+    # path to your certificate key
+    keyPath: mykey.key
+
 
 # Configures the target manager
 # Omitting this section will disable the target manager

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ targetManager:
   # before it is removed from the global target list
   # A duration of 0 means no removal
   unhealthyThreshold: 360m
-  # Scheme defines with which scheme sparrow should register itself (default to http)
+  # Scheme defines with which scheme sparrow should register itself
   scheme: http
   # Configuration options for the GitLab target manager
   gitlab:
@@ -326,6 +326,7 @@ in the startup YAML configuration file as shown in the [example configuration](#
 | `targetManager.gitlab.baseUrl`       | Base URL of the GitLab instance.                                                             |
 | `targetManager.gitlab.token`         | Token for authenticating with the GitLab instance.                                           |
 | `targetManager.gitlab.projectId`     | Project ID for the GitLab project used as a remote state backend.                            |
+| `targetManager.scheme`               | Should the target register itself as http or https. Can be `http` or `https`. This needs to be set to `https`, when `api.tls.enabled` == `true`|
 
 Currently, only one target manager exists: the Gitlab target manager. It uses a gitlab project as the remote state
 backend. The various `sparrow` instances can register themselves as targets in the project.
@@ -335,7 +336,7 @@ which is named after the DNS name of the `sparrow`. The state file contains the 
 
 ```json
 {
-  "url": "https://<SPARROW_DNS_NAME>",
+  "url": "<SCHEME>://<SPARROW_DNS_NAME>",
   "lastSeen": "2021-09-30T12:00:00Z"
 }
 ```

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -20,6 +20,7 @@ package api
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"net/http"
@@ -37,13 +38,21 @@ type API interface {
 }
 
 type api struct {
-	server *http.Server
-	router chi.Router
+	server    *http.Server
+	router    chi.Router
+	tlsConfig TLSConfig
 }
 
 // Config is the configuration for the data API
 type Config struct {
-	ListeningAddress string `yaml:"address" mapstructure:"address"`
+	ListeningAddress string    `yaml:"address" mapstructure:"address"`
+	Tls              TLSConfig `yaml:"tls" mapstructure:"tls"`
+}
+
+type TLSConfig struct {
+	Enabled  bool   `yaml:"enabled" mapstructure:"enabled"`
+	CertPath string `yaml:"certPath" mapstructure:"certPath"`
+	KeyPath  string `yaml:"keyPath" mapstructure:"keyPath"`
 }
 
 const (
@@ -51,12 +60,43 @@ const (
 	shutdownTimeout   = 30 * time.Second
 )
 
+func (a *Config) Validate() error {
+	if a.ListeningAddress == "" {
+		return fmt.Errorf("listening address cannot be empty")
+	}
+	if a.Tls.Enabled {
+		if a.Tls.CertPath == "" {
+			return fmt.Errorf("tls cert path cannot be empty")
+		}
+		if a.Tls.KeyPath == "" {
+			return fmt.Errorf("tls key path cannot be empty")
+		}
+	}
+	return nil
+}
+
+func buildTlsConfig(cfg TLSConfig) (*tls.Config, error) {
+	cert, err := tls.LoadX509KeyPair(cfg.CertPath, cfg.KeyPath)
+	if err != nil {
+		return nil, err
+	}
+
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+	}
+
+	return tlsConfig, nil
+}
+
 // New creates a new api
 func New(cfg Config) API {
 	r := chi.NewRouter()
+	var tlsconfig *tls.Config
+
 	return &api{
-		server: &http.Server{Addr: cfg.ListeningAddress, Handler: r, ReadHeaderTimeout: readHeaderTimeout},
-		router: r,
+		server:    &http.Server{Addr: cfg.ListeningAddress, Handler: r, ReadHeaderTimeout: readHeaderTimeout, TLSConfig: tlsconfig},
+		router:    r,
+		tlsConfig: cfg.Tls,
 	}
 }
 
@@ -74,8 +114,15 @@ func (a *api) Run(ctx context.Context) error {
 	go func(cErr chan error) {
 		defer close(cErr)
 		log.Info("Serving Api", "addr", a.server.Addr)
+		if a.tlsConfig.Enabled {
+			if err := a.server.ListenAndServeTLS(a.tlsConfig.CertPath, a.tlsConfig.KeyPath); err != nil {
+				log.Error("Failed to serve api", "error", err, "scheme", "https")
+				cErr <- err
+			}
+			return
+		}
 		if err := a.server.ListenAndServe(); err != nil {
-			log.Error("Failed to serve api", "error", err)
+			log.Error("Failed to serve api", "error", err, "scheme", "http")
 			cErr <- err
 		}
 	}(cErr)

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -20,7 +20,6 @@ package api
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"net/http"
@@ -75,26 +74,12 @@ func (a *Config) Validate() error {
 	return nil
 }
 
-func buildTlsConfig(cfg TLSConfig) (*tls.Config, error) {
-	cert, err := tls.LoadX509KeyPair(cfg.CertPath, cfg.KeyPath)
-	if err != nil {
-		return nil, err
-	}
-
-	tlsConfig := &tls.Config{
-		Certificates: []tls.Certificate{cert},
-	}
-
-	return tlsConfig, nil
-}
-
 // New creates a new api
 func New(cfg Config) API {
 	r := chi.NewRouter()
-	var tlsconfig *tls.Config
 
 	return &api{
-		server:    &http.Server{Addr: cfg.ListeningAddress, Handler: r, ReadHeaderTimeout: readHeaderTimeout, TLSConfig: tlsconfig},
+		server:    &http.Server{Addr: cfg.ListeningAddress, Handler: r, ReadHeaderTimeout: readHeaderTimeout},
 		router:    r,
 		tlsConfig: cfg.Tls,
 	}

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -236,3 +236,28 @@ func TestAPI_OkHandler(t *testing.T) {
 			rr.Body.String(), expected)
 	}
 }
+
+func TestConfig_Validate(t *testing.T) {
+	cases := []struct {
+		name    string
+		config  Config
+		wantErr bool
+	}{
+		{"Empty address", Config{}, true},
+		{"Empty certpath", Config{Tls: TLSConfig{Enabled: true}}, true},
+		{"Empty keypath", Config{Tls: TLSConfig{Enabled: true}}, true},
+
+		{"Valid config", Config{ListeningAddress: ":8080"}, false},
+		{"Valid tls config", Config{ListeningAddress: ":8080", Tls: TLSConfig{Enabled: true, CertPath: "./mycert.pem", KeyPath: "mykey.key"}}, false},
+		{"Valid tls config without tls", Config{ListeningAddress: ":8080", Tls: TLSConfig{Enabled: false}}, false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := c.config.Validate()
+			if (err != nil) != c.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, c.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -58,5 +58,5 @@ type FileLoaderConfig struct {
 
 // HasTargetManager returns true if the config has a target manager
 func (c *Config) HasTargetManager() bool {
-	return c.TargetManager != targets.TargetManagerConfig{}
+	return c.TargetManager.Enabled
 }

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -26,7 +26,6 @@ import (
 	"regexp"
 
 	"github.com/caas-team/sparrow/internal/logger"
-	"github.com/caas-team/sparrow/pkg/sparrow/targets"
 )
 
 // Validate validates the startup config
@@ -42,7 +41,7 @@ func (c *Config) Validate(ctx context.Context) (err error) {
 		err = errors.Join(err, vErr)
 	}
 
-	if c.TargetManager != (targets.TargetManagerConfig{}) {
+	if c.HasTargetManager() {
 		if vErr := c.TargetManager.Validate(ctx); vErr != nil {
 			log.Error("The target manager configuration is invalid")
 			err = errors.Join(err, vErr)

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -49,6 +49,11 @@ func (c *Config) Validate(ctx context.Context) (err error) {
 		}
 	}
 
+	if vErr := c.Api.Validate(); vErr != nil {
+		log.Error("The api configuration is invalid")
+		err = errors.Join(err, vErr)
+	}
+
 	if err != nil {
 		return fmt.Errorf("validation of configuration failed: %w", err)
 	}

--- a/pkg/config/validate_test.go
+++ b/pkg/config/validate_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/caas-team/sparrow/internal/helper"
+	"github.com/caas-team/sparrow/pkg/api"
 )
 
 func TestConfig_Validate(t *testing.T) {
@@ -38,6 +39,9 @@ func TestConfig_Validate(t *testing.T) {
 			name: "config ok",
 			config: Config{
 				SparrowName: "sparrow.com",
+				Api: api.Config{
+					ListeningAddress: ":8080",
+				},
 				Loader: LoaderConfig{
 					Type: "http",
 					Http: HttpLoaderConfig{
@@ -57,6 +61,9 @@ func TestConfig_Validate(t *testing.T) {
 		{
 			name: "loader - url missing",
 			config: Config{
+				Api: api.Config{
+					ListeningAddress: ":8080",
+				},
 				SparrowName: "sparrow.com",
 				Loader: LoaderConfig{
 					Type: "http",
@@ -77,6 +84,9 @@ func TestConfig_Validate(t *testing.T) {
 		{
 			name: "loader - url malformed",
 			config: Config{
+				Api: api.Config{
+					ListeningAddress: ":8080",
+				},
 				SparrowName: "sparrow.com",
 				Loader: LoaderConfig{
 					Type: "http",
@@ -96,6 +106,9 @@ func TestConfig_Validate(t *testing.T) {
 		{
 			name: "loader - retry count to high",
 			config: Config{
+				Api: api.Config{
+					ListeningAddress: ":8080",
+				},
 				SparrowName: "sparrow.com",
 				Loader: LoaderConfig{
 					Type: "http",
@@ -115,6 +128,26 @@ func TestConfig_Validate(t *testing.T) {
 		{
 			name: "loader - file path malformed",
 			config: Config{
+				Api: api.Config{
+					ListeningAddress: ":8080",
+				},
+				SparrowName: "sparrow.com",
+				Loader: LoaderConfig{
+					Type: "file",
+					File: FileLoaderConfig{
+						Path: "",
+					},
+					Interval: time.Second,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "targetManager - Wrong Scheme",
+			config: Config{
+				Api: api.Config{
+					ListeningAddress: ":8080",
+				},
 				SparrowName: "sparrow.com",
 				Loader: LoaderConfig{
 					Type: "file",

--- a/pkg/sparrow/run_test.go
+++ b/pkg/sparrow/run_test.go
@@ -48,7 +48,8 @@ func TestSparrow_Run_FullComponentStart(t *testing.T) {
 			Interval: time.Second * 1,
 		},
 		TargetManager: targets.TargetManagerConfig{
-			Type: "gitlab",
+			Enabled: true,
+			Type:    "gitlab",
 			General: targets.General{
 				CheckInterval:        time.Second * 1,
 				RegistrationInterval: time.Second * 1,

--- a/pkg/sparrow/targets/errors.go
+++ b/pkg/sparrow/targets/errors.go
@@ -31,4 +31,6 @@ var (
 	ErrInvalidUpdateInterval = errors.New("invalid update interval")
 	// ErrInvalidInteractorType is returned when the interactor type isn't recognized
 	ErrInvalidInteractorType = errors.New("invalid interactor type")
+	// ErrInvalidScheme is returned when the scheme is not http or https
+	ErrInvalidScheme = errors.New("scheme must be 'http' of 'https'")
 )

--- a/pkg/sparrow/targets/manager.go
+++ b/pkg/sparrow/targets/manager.go
@@ -202,7 +202,7 @@ func (t *manager) update(ctx context.Context) error {
 		AuthorEmail:   fmt.Sprintf("%s@sparrow", t.name),
 		AuthorName:    t.name,
 		CommitMessage: "Updated registration",
-		Content:       checks.GlobalTarget{Url: fmt.Sprintf("https://%s", t.name), LastSeen: time.Now().UTC()},
+		Content:       checks.GlobalTarget{Url: fmt.Sprintf("%s://%s", t.cfg.Scheme, t.name), LastSeen: time.Now().UTC()},
 	}
 	f.SetFileName(fmt.Sprintf("%s.json", t.name))
 
@@ -230,7 +230,9 @@ func (t *manager) refreshTargets(ctx context.Context) error {
 
 	// filter unhealthy targets - this may be removed in the future
 	for _, target := range targets {
-		if !t.registered && target.Url == fmt.Sprintf("https://%s", t.name) {
+		// FIXME: this should be a more reliable check ideally
+		// this would report false negatives if sparrows dns stays the same but scheme change from http to https
+		if !t.registered && target.Url == fmt.Sprintf("%s://%s", t.cfg.Scheme, t.name) {
 			log.Debug("Found self as global target", "lastSeenMin", time.Since(target.LastSeen).Minutes())
 			t.registered = true
 		}

--- a/pkg/sparrow/targets/manager.go
+++ b/pkg/sparrow/targets/manager.go
@@ -230,8 +230,6 @@ func (t *manager) refreshTargets(ctx context.Context) error {
 
 	// filter unhealthy targets - this may be removed in the future
 	for _, target := range targets {
-		// FIXME: this should be a more reliable check ideally
-		// this would report false negatives if sparrows dns stays the same but scheme change from http to https
 		if !t.registered && target.Url == fmt.Sprintf("%s://%s", t.cfg.Scheme, t.name) {
 			log.Debug("Found self as global target", "lastSeenMin", time.Since(target.LastSeen).Minutes())
 			t.registered = true

--- a/pkg/sparrow/targets/manager_test.go
+++ b/pkg/sparrow/targets/manager_test.go
@@ -120,7 +120,7 @@ func Test_gitlabTargetManager_refreshTargets(t *testing.T) {
 				targets:    nil,
 				interactor: remote,
 				name:       "test",
-				cfg:        General{UnhealthyThreshold: time.Hour},
+				cfg:        General{UnhealthyThreshold: time.Hour, Scheme: "https"},
 			}
 			if err := gtm.refreshTargets(context.Background()); (err != nil) != (tt.wantErr != nil) {
 				t.Fatalf("refreshTargets() error = %v, wantErr %v", err, tt.wantErr)
@@ -192,7 +192,7 @@ func Test_gitlabTargetManager_refreshTargets_No_Threshold(t *testing.T) {
 				targets:    nil,
 				interactor: remote,
 				name:       "test",
-				cfg:        General{UnhealthyThreshold: 0},
+				cfg:        General{UnhealthyThreshold: 0, Scheme: "https"},
 			}
 			if err := gtm.refreshTargets(context.Background()); (err != nil) != (tt.wantErr != nil) {
 				t.Fatalf("refreshTargets() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/sparrow/targets/targetmanager.go
+++ b/pkg/sparrow/targets/targetmanager.go
@@ -61,6 +61,7 @@ type General struct {
 
 // TargetManagerConfig is the configuration for the target manager
 type TargetManagerConfig struct {
+	Enabled bool `yaml:"enabled" mapstructure:"enabled"`
 	// Type defines which target manager to use
 	Type interactor.Type `yaml:"type" mapstructure:"type"`
 	// General is the general configuration of the target manager

--- a/pkg/sparrow/targets/targetmanager.go
+++ b/pkg/sparrow/targets/targetmanager.go
@@ -54,6 +54,9 @@ type General struct {
 	// before it is removed from the global target list.
 	// A duration of 0 means no removal.
 	UnhealthyThreshold time.Duration `yaml:"unhealthyThreshold" mapstructure:"unhealthyThreshold"`
+	// Scheme is the scheme used for the remote target manager
+	// Can either be http or https
+	Scheme string `yaml:"scheme" mapstructure:"scheme"`
 }
 
 // TargetManagerConfig is the configuration for the target manager
@@ -83,6 +86,17 @@ func (c *TargetManagerConfig) Validate(ctx context.Context) error {
 	if c.UpdateInterval < 0 {
 		log.Error("The update interval should be equal or above 0", "interval", c.UpdateInterval)
 		return ErrInvalidUpdateInterval
+	}
+
+	if c.Scheme == "" {
+		// BUG: mapstructure, which viper uses to decode the config file does not have a unmarshaling interface like json.UnmarshalJSON or yaml.UnmarshalYAML
+		// so we need to set the default value here, which is stupid, but maybe this gets implemented upstream someday
+		c.Scheme = "http"
+	}
+
+	if c.Scheme != "http" && c.Scheme != "https" {
+		log.Error("The scheme should be either of: 'http', 'https'", "scheme", c.Scheme)
+		return ErrInvalidScheme
 	}
 
 	switch c.Type {

--- a/pkg/sparrow/targets/targetmanager.go
+++ b/pkg/sparrow/targets/targetmanager.go
@@ -88,12 +88,6 @@ func (c *TargetManagerConfig) Validate(ctx context.Context) error {
 		return ErrInvalidUpdateInterval
 	}
 
-	if c.Scheme == "" {
-		// BUG: mapstructure, which viper uses to decode the config file does not have a unmarshaling interface like json.UnmarshalJSON or yaml.UnmarshalYAML
-		// so we need to set the default value here, which is stupid, but maybe this gets implemented upstream someday
-		c.Scheme = "http"
-	}
-
 	if c.Scheme != "http" && c.Scheme != "https" {
 		log.Error("The scheme should be either of: 'http', 'https'", "scheme", c.Scheme)
 		return ErrInvalidScheme

--- a/pkg/sparrow/targets/targetmanager_test.go
+++ b/pkg/sparrow/targets/targetmanager_test.go
@@ -39,6 +39,7 @@ func TestTargetManagerConfig_Validate(t *testing.T) {
 			cfg: TargetManagerConfig{
 				Type: "gitlab",
 				General: General{
+					Scheme:               "http",
 					UnhealthyThreshold:   1 * time.Second,
 					CheckInterval:        1 * time.Second,
 					RegistrationInterval: 1 * time.Second,
@@ -51,6 +52,7 @@ func TestTargetManagerConfig_Validate(t *testing.T) {
 			cfg: TargetManagerConfig{
 				Type: "gitlab",
 				General: General{
+					Scheme:               "http",
 					UnhealthyThreshold:   0,
 					CheckInterval:        1 * time.Second,
 					RegistrationInterval: 0,
@@ -63,6 +65,7 @@ func TestTargetManagerConfig_Validate(t *testing.T) {
 			cfg: TargetManagerConfig{
 				Type: "gitlab",
 				General: General{
+					Scheme:               "http",
 					UnhealthyThreshold:   1 * time.Second,
 					CheckInterval:        0,
 					RegistrationInterval: 1 * time.Second,
@@ -76,6 +79,7 @@ func TestTargetManagerConfig_Validate(t *testing.T) {
 			cfg: TargetManagerConfig{
 				Type: "gitlab",
 				General: General{
+					Scheme:               "http",
 					UnhealthyThreshold:   -1 * time.Second,
 					CheckInterval:        1 * time.Second,
 					RegistrationInterval: 1 * time.Second,
@@ -89,6 +93,7 @@ func TestTargetManagerConfig_Validate(t *testing.T) {
 			cfg: TargetManagerConfig{
 				Type: "unknown",
 				General: General{
+					Scheme:               "http",
 					UnhealthyThreshold:   1 * time.Second,
 					CheckInterval:        1 * time.Second,
 					RegistrationInterval: 1 * time.Second,
@@ -96,6 +101,61 @@ func TestTargetManagerConfig_Validate(t *testing.T) {
 				},
 			},
 			wantErr: true,
+		},
+		{
+			name: "invalid config - wrong scheme",
+			cfg: TargetManagerConfig{
+				Type: "gitlab",
+				General: General{
+					Scheme:               "tcp",
+					UnhealthyThreshold:   1 * time.Second,
+					CheckInterval:        1 * time.Second,
+					RegistrationInterval: 1 * time.Second,
+					UpdateInterval:       1 * time.Second,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid config - no scheme",
+			cfg: TargetManagerConfig{
+				Type: "gitlab",
+				General: General{
+					UnhealthyThreshold:   1 * time.Second,
+					CheckInterval:        1 * time.Second,
+					RegistrationInterval: 1 * time.Second,
+					UpdateInterval:       1 * time.Second,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid config - http",
+			cfg: TargetManagerConfig{
+				Type: "gitlab",
+				General: General{
+					Scheme:               "http",
+					UnhealthyThreshold:   1 * time.Second,
+					CheckInterval:        1 * time.Second,
+					RegistrationInterval: 1 * time.Second,
+					UpdateInterval:       1 * time.Second,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid config - https",
+			cfg: TargetManagerConfig{
+				Type: "gitlab",
+				General: General{
+					Scheme:               "https",
+					UnhealthyThreshold:   1 * time.Second,
+					CheckInterval:        1 * time.Second,
+					RegistrationInterval: 1 * time.Second,
+					UpdateInterval:       1 * time.Second,
+				},
+			},
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Motivation

Closes #144 

This pr implements the features requested in #144 

### Serve API over https
Adds a tls config to allow configuring the server to use https instead of http

### HTTP targets in targetmanager
Changes the targetmanager to allow non https targets by setting a new scheme value in the config

### Enabled flag for targetmanager
To make our lives a bit easier when dealing with default values, I've added a flag to the targetManager config for enabling it explicitly instead of implicitly enabling it as we did before
## Changes

<!-- Explain what you've changed -->

For additional information look at the commits.

## Tests done

<!-- Explain what tests you've done and if your tests worked -->

- [x] Unit tests succeeded
- [x] E2E tests succeeded

## TODO

- [x] I've assigned this PR to myself
- [x] I've labeled this PR correctly
- [x] I've fixed the tests
<!-- Add open ToDo's to this checklist -->