### PR TITLE
feat: fix dangaling metrics regading status code

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,17 @@ latency:
   - Description: Latency with status information of targets
   - Labelled with `target` and `status`
 
+- `sparrow_latency_seconds`
+  - Type: Gauge
+  - Description: Latency information of targets
+  - Labelled with `target`
+
 - `sparrow_latency_count`
+  - Type: Counter
+  - Description: Count of latency checks including the status of targets
+  - Labelled with `target` and `status`
+
+- `sparrow_latency_total_count`
   - Type: Counter
   - Description: Count of latency checks done
   - Labelled with `target`

--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ latency:
 
 - `sparrow_latency_duration_seconds`
   - Type: Gauge
-  - Description: Latency with status information of targets
+  - Description: Latency with status information of targets. This metric is DEPRECATED
   - Labelled with `target` and `status`
 
 - `sparrow_latency_seconds`
@@ -402,11 +402,6 @@ latency:
   - Labelled with `target`
 
 - `sparrow_latency_count`
-  - Type: Counter
-  - Description: Count of latency checks including the status of targets
-  - Labelled with `target` and `status`
-
-- `sparrow_latency_total_count`
   - Type: Counter
   - Description: Count of latency checks done
   - Labelled with `target`

--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ latency:
 
 - `sparrow_latency_duration_seconds`
   - Type: Gauge
-  - Description: Latency with status information of targets. This metric is DEPRECATED
+  - Description: Latency with status information of targets. This metric is DEPRECATED. Use `sparrow_latency_seconds`. 
   - Labelled with `target` and `status`
 
 - `sparrow_latency_seconds`

--- a/pkg/checks/latency/latency.go
+++ b/pkg/checks/latency/latency.go
@@ -150,7 +150,7 @@ func newMetrics() metrics {
 		duration: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Name: "sparrow_latency_duration_seconds",
-				Help: "DEPRECATED Latency with status information of targets",
+				Help: "DEPRECATED Latency with status information of targets. Use sparrow_latency_seconds.",
 			},
 			[]string{
 				"target",

--- a/pkg/checks/latency/latency.go
+++ b/pkg/checks/latency/latency.go
@@ -74,7 +74,6 @@ type metrics struct {
 	duration      *prometheus.GaugeVec
 	totalDuration *prometheus.GaugeVec
 	count         *prometheus.CounterVec
-	totalCount    *prometheus.CounterVec
 	histogram     *prometheus.HistogramVec
 }
 
@@ -151,7 +150,7 @@ func newMetrics() metrics {
 		duration: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Name: "sparrow_latency_duration_seconds",
-				Help: "Latency with status information of targets",
+				Help: "DEPRECATED Latency with status information of targets",
 			},
 			[]string{
 				"target",
@@ -170,16 +169,6 @@ func newMetrics() metrics {
 		count: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "sparrow_latency_count",
-				Help: "Count of latency checks including the status of targets",
-			},
-			[]string{
-				"target",
-				"status",
-			},
-		),
-		totalCount: prometheus.NewCounterVec(
-			prometheus.CounterOpts{
-				Name: "sparrow_latency_total_count",
 				Help: "Count of latency checks done",
 			},
 			[]string{
@@ -204,7 +193,6 @@ func (l *Latency) GetMetricCollectors() []prometheus.Collector {
 		l.metrics.duration,
 		l.metrics.totalDuration,
 		l.metrics.count,
-		l.metrics.totalCount,
 		l.metrics.histogram,
 	}
 }
@@ -258,10 +246,9 @@ func (l *Latency) check(ctx context.Context) map[string]result {
 			l.metrics.duration.DeletePartialMatch(prometheus.Labels{"target": target})
 			l.metrics.duration.WithLabelValues(target, strconv.Itoa(results[target].Code)).Set(results[target].Total)
 			l.metrics.totalDuration.WithLabelValues(target).Set(results[target].Total)
-			l.metrics.count.WithLabelValues(target, strconv.Itoa(results[target].Code)).Inc()
-			l.metrics.totalCount.WithLabelValues(target).Inc()
+			l.metrics.count.WithLabelValues(target).Inc()
 			l.metrics.histogram.WithLabelValues(target).Observe(results[target].Total)
-			l.metrics.totalCount.WithLabelValues(target).Inc()
+			l.metrics.count.WithLabelValues(target).Inc()
 		}()
 	}
 


### PR DESCRIPTION
## Motivation

<!-- Explain what motivated you to do these changes -->

Referes to https://github.com/caas-team/sparrow/issues/133

## Changes

<!-- Explain what you've changed -->

The metric `sparrow_latency_duration_seconds` will now be clear before the new duration with label status is exposed.
Dangling metrics that do not show the current status are cleared up.

Additionally, I have introduced two new metrics like @puffitos suggested.

- `sparrow_latency_seconds`
- `sparrow_latency_count` (old `sparrow_latency_count` has been renamed to `sparrow_latency_total_count`)

For additional information look at the commits.

## Tests done

<!-- Explain what tests you've done and if your tests worked -->

- [x] Unit tests succeeded
- [x] E2E tests succeeded

First run:
```text
# TYPE sparrow_latency_duration_seconds gauge
sparrow_latency_duration_seconds{status="200",target="https://gitlab.devops.telekom.de"} 0.222653973
sparrow_latency_duration_seconds{status="200",target="https://httpstat.us/random/200,500-504"} 0.711660485
sparrow_latency_duration_seconds{status="418",target="https://yam.telekom.de"} 0.214198665
```

Second run:
```
# TYPE sparrow_latency_duration_seconds gauge
sparrow_latency_duration_seconds{status="200",target="https://gitlab.devops.telekom.de"} 0.24624422
sparrow_latency_duration_seconds{status="418",target="https://yam.telekom.de"} 0.212984192
sparrow_latency_duration_seconds{status="502",target="https://httpstat.us/random/200,500-504"} 0.69023805
```

## TODO

- [x] I've assigned this PR to myself
- [x] I've labeled this PR correctly

<!-- Add open ToDo's to this checklist -->