### PR TITLE
fix: enrich targets now accepts any scheme

### DIFF
--- a/pkg/sparrow/run.go
+++ b/pkg/sparrow/run.go
@@ -138,10 +138,7 @@ func (s *Sparrow) enrichTargets(ctx context.Context, cfg runtime.Config) runtime
 		return cfg
 	}
 
-	fmt.Println("iaiaiai", s.tarMan.GetTargets())
-
 	for _, gt := range s.tarMan.GetTargets() {
-		l.Info("Enriching targets with global targets", "url", gt)
 		u, err := url.Parse(gt.Url)
 		if err != nil {
 			l.Error("Failed to parse global target URL", "error", err, "url", gt.Url)

--- a/pkg/sparrow/run_test.go
+++ b/pkg/sparrow/run_test.go
@@ -112,6 +112,7 @@ func TestSparrow_Run_ContextCancel(t *testing.T) {
 // TestSparrow_enrichTargets tests that the enrichTargets method
 // updates the targets of the configured checks.
 func TestSparrow_enrichTargets(t *testing.T) {
+	t.Parallel()
 	now := time.Now()
 	testTarget := "https://localhost.de"
 	gt := []checks.GlobalTarget{
@@ -234,6 +235,28 @@ func TestSparrow_enrichTargets(t *testing.T) {
 			expected: runtime.Config{
 				Health: &health.Config{
 					Targets: []string{testTarget},
+				},
+			},
+		},
+		{
+			name: "global targets contains http and https - dns validation still works does not fail and splits off scheme",
+			config: runtime.Config{
+				Dns: &dns.Config{
+					Targets: []string{},
+				},
+			},
+			globalTargets: []checks.GlobalTarget{
+				{
+					Url:      "http://az1.sparrow.com",
+					LastSeen: now,
+				},
+				{
+					Url: "https://az2.sparrow.com",
+				},
+			},
+			expected: runtime.Config{
+				Dns: &dns.Config{
+					Targets: []string{"az1.sparrow.com", "az2.sparrow.com"},
 				},
 			},
 		},

--- a/pkg/sparrow/run_test.go
+++ b/pkg/sparrow/run_test.go
@@ -249,7 +249,7 @@ func TestSparrow_enrichTargets(t *testing.T) {
 					SparrowName: "sparrow.com",
 				},
 			}
-			got := s.enrichTargets(tt.config)
+			got := s.enrichTargets(context.Background(), tt.config)
 			assert.Equal(t, tt.expected, got)
 		})
 	}


### PR DESCRIPTION
## Motivation

Closes #148 

This improves the logic in `enrichTargets` to account for any scheme, be that http, https, tcp whatever floats your boat, as long as it's a valid url we're happy.

## Changes

Parse the url into a `net.Url` so we grab the dns name in an easier way for the dns check.

For additional information look at the commits.

## Tests done
I've tested it with the latency and dns check enabled using mixed set of targets configured with HTTP and  HTTPS. Seemed to work fine
<!-- Explain what tests you've done and if your tests worked -->

- [x] Unit tests succeeded
- [x] E2E tests succeeded

## TODO

- [x] I've assigned this PR to myself
- [x] I've labeled this PR correctly

<!-- Add open ToDo's to this checklist -->