### PR TITLE
feat: add config shorthand

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,7 +43,7 @@ func NewCmdRoot(version string) *cobra.Command {
 		initConfig(cfgFile)
 	})
 
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.sparrow.yaml)")
+	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file (default is $HOME/.sparrow.yaml)")
 
 	return rootCmd
 }

--- a/docs/sparrow.md
+++ b/docs/sparrow.md
@@ -10,7 +10,7 @@ The check results are exposed via an API.
 ### Options
 
 ```
-      --config string   config file (default is $HOME/.sparrow.yaml)
+  -c, --config string   config file (default is $HOME/.sparrow.yaml)
   -h, --help            help for sparrow
 ```
 

--- a/docs/sparrow_run.md
+++ b/docs/sparrow_run.md
@@ -29,7 +29,7 @@ sparrow run [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.sparrow.yaml)
+  -c, --config string   config file (default is $HOME/.sparrow.yaml)
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
## Motivation

To add a `-c` flag shorthand for the config. We should have this since it's a common flag that is always passed to the CLI and it's cumbersome to always write the whole `--config` flag everytime you want to run sparrow.

## Changes

Added a shorthand for the `--config` flag.

For additional information look at the commits.

## Tests done

New help description reflects the new shorthand:
```sh
❯ go run . 
Sparrow is an infrastructure monitoring agent that is able to perform different checks.
The check results are exposed via an API.

Usage:
  sparrow [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  run         Run sparrow

Flags:
  -c, --config string   config file (default is $HOME/.sparrow.yaml)
  -h, --help            help for sparrow

Use "sparrow [command] --help" for more information about a command.

❯ go run . run -c ./.tmp/config/start.yaml
Using config file: ./.tmp/config/start.yaml
{"time":"2024-10-15T23:42:07.797637971+02:00","level":"INFO","source":{"function":"github.com/caas-team/sparrow/cmd.NewCmdRun.run.func1","file":"/home/tom/dev/sparrow/cmd/run.go","line":89},"msg":"Running sparrow"}
```

- [ ] ~Unit tests succeeded~ - Not applicable
- [ ] ~E2E tests succeeded~ - Not applicable

## TODO

- [x] I've assigned this PR to myself
- [x] I've labeled this PR correctly

<!-- Add open ToDo's to this checklist -->