### PR TITLE
fix: allow tls without a custom certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -667,9 +667,12 @@ telemetry:
   # The token to use for authentication.
   # If the exporter does not require a token, this can be left empty.
   token: ""
-  # The path to the tls certificate to use.
-  # To disable tls, either set this to an empty string or set it to insecure.
-  certPath: ""
+  tls:
+    # Enable or disable TLS
+    enabled: true
+    # The path to the tls certificate to use.
+    # Only required if your otel endpoint uses custom TLS certificates
+    certPath: ""
 ```
 
 Since [OTLP](https://opentelemetry.io/docs/specs/otlp/) is a standard protocol, you can choose any collector that supports it. The `stdout` exporter can be used for debugging purposes to print telemetry data to the console, while the `noop` exporter disables telemetry. If an external collector is used, a bearer token for authentication and a TLS certificate path for secure communication can be provided.

--- a/pkg/sparrow/metrics/config.go
+++ b/pkg/sparrow/metrics/config.go
@@ -34,9 +34,14 @@ type Config struct {
 	// Url is the Url of the collector to which the traces are exported
 	Url string `yaml:"url" mapstructure:"url"`
 	// Token is the token used to authenticate with the collector
-	Token string `yaml:"token" mapstructure:"token"`
+	Token string    `yaml:"token" mapstructure:"token"`
+	Tls   TLSConfig `yaml:"tls" mapstructure:"tls"`
+}
+
+type TLSConfig struct {
 	// CertPath is the path to the tls certificate file
 	CertPath string `yaml:"certPath" mapstructure:"certPath"`
+	Enabled  bool   `yaml:"enabled" mapstructure:"enabled"`
 }
 
 func (c *Config) Validate(ctx context.Context) error {

--- a/pkg/sparrow/metrics/exporter.go
+++ b/pkg/sparrow/metrics/exporter.go
@@ -122,12 +122,13 @@ func newGRPCExporter(ctx context.Context, config *Config) (sdktrace.SpanExporter
 		otlptracegrpc.WithEndpoint(config.Url),
 		otlptracegrpc.WithHeaders(headers),
 	}
-	if config.Tls.Enabled {
-		if tlsCfg != nil {
-			opts = append(opts, otlptracegrpc.WithTLSCredentials(credentials.NewTLS(tlsCfg)))
-		}
-	} else {
+
+	if !config.Tls.Enabled {
 		opts = append(opts, otlptracegrpc.WithInsecure())
+		return otlptracegrpc.New(ctx, opts...)
+	}
+	if tlsCfg != nil {
+		opts = append(opts, otlptracegrpc.WithTLSCredentials(credentials.NewTLS(tlsCfg)))
 	}
 
 	return otlptracegrpc.New(ctx, opts...)

--- a/pkg/sparrow/metrics/metrics.go
+++ b/pkg/sparrow/metrics/metrics.go
@@ -52,6 +52,8 @@ type manager struct {
 }
 
 // New initializes the metrics and returns the PrometheusMetrics
+//
+//nolint:gocritic
 func New(config Config) Provider {
 	registry := prometheus.NewRegistry()
 


### PR DESCRIPTION
## Motivation

<!-- Explain what motivated you to do these changes -->
Fixes #211 
## Changes

<!-- Explain what you've changed -->
Added a new option for enabling TLS without custom certs. I changed the config file a bit for this, grouping the tls stuff into their own object. Check the readme for more info

## Tests done

<!-- Explain what tests you've done and if your tests worked -->
- [x] Tested against jaeger instance exposed over https
## TODO

- [x] I've assigned this PR to myself
- [x] I've labeled this PR correctly

<!-- Add open ToDo's to this checklist -->