### PR TITLE
refactor: exporter config

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,15 +81,14 @@ The binary is available for several distributions. To install the binary, use a 
 Replace `${RELEASE_VERSION}` with the desired release version:
 
 ```sh
-curl https://github.com/caas-team/sparrow/releases/download/v${RELEASE_VERSION}/sparrow_${RELEASE_VERSION}_linux_amd64.tar.gz -Lo sparrow.tar.gz
-curl https://github.com/caas-team/sparrow/releases/download/v${RELEASE_VERSION}/sparrow_${RELEASE_VERSION}_checksums.txt -Lo checksums.txt
+export RELEASE_VERSION=0.5.0
 ```
 
-For example, for release `v0.3.1`:
+Download the binary:
 
 ```sh
-curl https://github.com/caas-team/sparrow/releases/download/v0.3.1/sparrow_0.3.1_linux_amd64.tar.gz -Lo sparrow.tar.gz
-curl https://github.com/caas-team/sparrow/releases/download/v0.3.1/sparrow_0.3.1_checksums.txt -Lo checksums.txt
+curl https://github.com/caas-team/sparrow/releases/download/v${RELEASE_VERSION}/sparrow_${RELEASE_VERSION}_linux_amd64.tar.gz -Lo sparrow.tar.gz
+curl https://github.com/caas-team/sparrow/releases/download/v${RELEASE_VERSION}/sparrow_${RELEASE_VERSION}_checksums.txt -Lo checksums.txt
 ```
 
 Extract the binary:
@@ -291,9 +290,13 @@ telemetry:
   # The token to use for authentication.
   # If the exporter does not require a token, this can be left empty.
   token: ""
-  # The path to the tls certificate to use.
-  # To disable tls, either set this to an empty string or set it to insecure.
-  certPath: ""
+  # Configures tls for the telemetry exporter
+  tls:
+    # Enable or disable TLS
+    enabled: true
+    # The path to the tls certificate to use.
+    # Only required if your otel endpoint uses custom TLS certificates
+    certPath: ""
 ```
 
 #### Loader
@@ -644,17 +647,21 @@ Replace `<sparrow_instance_address>` with the actual address of your `sparrow` i
 
 The `sparrow` supports exporting telemetry data using the OpenTelemetry Protocol (OTLP). This allows users to choose their preferred telemetry provider and collector. The following configuration options are available for setting up telemetry:
 
-| Field      | Type     | Description                                                              |
-| ---------- | -------- | ------------------------------------------------------------------------ |
-| `exporter` | `string` | The telemetry exporter to use. Options: `grpc`, `http`, `stdout`, `noop` |
-| `url`      | `string` | The address to export telemetry to                                       |
-| `token`    | `string` | The token to use for authentication                                      |
-| `certPath` | `string` | The path to the TLS certificate to use                                   |
+| Field          | Type     | Description                                                                 |
+| -------------- | -------- | --------------------------------------------------------------------------- |
+| `enabled`      | `bool`   | Whether to enable telemetry. Default: `false`                               |
+| `exporter`     | `string` | The telemetry exporter to use. Options: `grpc`, `http`, `stdout`, `noop`    |
+| `url`          | `string` | The address to export telemetry to.                                         |
+| `token`        | `string` | The token to use for authentication.                                        |
+| `tls.enabled`  | `bool`   | Enable or disable TLS.                                                      |
+| `tls.certPath` | `string` | The path to the TLS certificate to use. Only required if custom TLS is used |
 
 For example, to export telemetry data using OTLP via gRPC, you can add the following configuration to your [startup configuration](#startup):
 
 ```yaml
 telemetry:
+  # Whether to enable telemetry. (default: false)
+  enabled: true
   # The telemetry exporter to use.
   # Options:
   # grpc: Exports telemetry using OTLP via gRPC.

--- a/pkg/sparrow/metrics/config.go
+++ b/pkg/sparrow/metrics/config.go
@@ -34,14 +34,16 @@ type Config struct {
 	// Url is the Url of the collector to which the traces are exported
 	Url string `yaml:"url" mapstructure:"url"`
 	// Token is the token used to authenticate with the collector
-	Token string    `yaml:"token" mapstructure:"token"`
-	Tls   TLSConfig `yaml:"tls" mapstructure:"tls"`
+	Token string `yaml:"token" mapstructure:"token"`
+	// TLS holds the tls configuration
+	TLS TLSConfig `yaml:"tls" mapstructure:"tls"`
 }
 
 type TLSConfig struct {
+	// Enabled is a flag to enable or disable the tls
+	Enabled bool `yaml:"enabled" mapstructure:"enabled"`
 	// CertPath is the path to the tls certificate file
 	CertPath string `yaml:"certPath" mapstructure:"certPath"`
-	Enabled  bool   `yaml:"enabled" mapstructure:"enabled"`
 }
 
 func (c *Config) Validate(ctx context.Context) error {


### PR DESCRIPTION
## Motivation

To address [this code smell](https://github.com/caas-team/sparrow/pull/212#pullrequestreview-2372481730) aswell as adding missing telemetry configs to our documentation.

## Changes

* refactor: add common exporter config struct instead of multiple returns
* docs: add missing docs for exporter config

For additional information look at the commits.

## Tests done

<!-- Explain what tests you've done and if your tests worked -->

- [x] Unit tests succeeded
- [ ] ~E2E tests succeeded~ - not applicable

## TODO

- [x] I've assigned this PR to myself
- [x] I've labeled this PR correctly

<!-- Add open ToDo's to this checklist -->