### PR TITLE
feat/target-manager-registered-metric

### DIFF
--- a/pkg/sparrow/handlers.go
+++ b/pkg/sparrow/handlers.go
@@ -24,10 +24,11 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
 	"github.com/caas-team/sparrow/internal/logger"
 	"github.com/caas-team/sparrow/pkg/api"
 	"github.com/go-chi/chi/v5"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"gopkg.in/yaml.v3"
 )
 

--- a/pkg/sparrow/run.go
+++ b/pkg/sparrow/run.go
@@ -82,7 +82,7 @@ func New(cfg *config.Config) *Sparrow {
 	}
 
 	if cfg.HasTargetManager() {
-		gm := targets.NewManager(cfg.SparrowName, cfg.TargetManager)
+		gm := targets.NewManager(cfg.SparrowName, cfg.TargetManager, m)
 		sparrow.tarMan = gm
 	}
 	sparrow.loader = config.NewLoader(cfg, sparrow.cRuntime)

--- a/pkg/sparrow/targets/manager_test.go
+++ b/pkg/sparrow/targets/manager_test.go
@@ -121,6 +121,7 @@ func Test_gitlabTargetManager_refreshTargets(t *testing.T) {
 				interactor: remote,
 				name:       "test",
 				cfg:        General{UnhealthyThreshold: time.Hour, Scheme: "https"},
+				metrics:    newMetrics(),
 			}
 			if err := gtm.refreshTargets(context.Background()); (err != nil) != (tt.wantErr != nil) {
 				t.Fatalf("refreshTargets() error = %v, wantErr %v", err, tt.wantErr)
@@ -193,6 +194,7 @@ func Test_gitlabTargetManager_refreshTargets_No_Threshold(t *testing.T) {
 				interactor: remote,
 				name:       "test",
 				cfg:        General{UnhealthyThreshold: 0, Scheme: "https"},
+				metrics:    newMetrics(),
 			}
 			if err := gtm.refreshTargets(context.Background()); (err != nil) != (tt.wantErr != nil) {
 				t.Fatalf("refreshTargets() error = %v, wantErr %v", err, tt.wantErr)
@@ -304,6 +306,7 @@ func Test_gitlabTargetManager_register(t *testing.T) {
 			}
 			gtm := &manager{
 				interactor: glmock,
+				metrics:    newMetrics(),
 			}
 			if err := gtm.register(context.Background()); (err != nil) != tt.wantErr {
 				t.Fatalf("register() error = %v, wantErr %v", err, tt.wantErr)
@@ -830,6 +833,7 @@ func mockGitlabTargetManager(g *remotemock.MockClient, name string) *manager { /
 		done:       make(chan struct{}, 1),
 		interactor: g,
 		name:       name,
+		metrics:    newMetrics(),
 		cfg: General{
 			CheckInterval:        100 * time.Millisecond,
 			UnhealthyThreshold:   1 * time.Second,


### PR DESCRIPTION

## Motivation

Part of https://github.com/caas-team/sparrow/issues/231

A metric in the target manager component should expose the current state of the sparrow (whether it's registered or not.)

## Changes

- Added metrics to target manager
- Added new gauge metric (0/1) to the targetmanager, to expose the registration status
- Set the new metric to 0/1 upon successful registration & deregistration of sparrow.


## Tests done

Manual E2E tests were done. The sparrow exposes the new metric and it's 0 on start and is set to 1 upon registration.

```shell
❯ curl localhost:8080/metrics | rg register
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 12718    0 12718    0     0  8112k      0 --:--:-- --:--:-- --:--:-- 12.1M
# HELP sparrow_target_manager_registered Indicates whether the instance is registered as a global target
# TYPE sparrow_target_manager_registered gauge
sparrow_target_manager_registered 1
❯ curl localhost:8080/metrics | rg register
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  9743    0  9743    0     0  6859k      0 --:--:-- --:--:-- --:--:-- 9514k
# HELP sparrow_target_manager_registered Indicates whether the instance is registered as a global target
# TYPE sparrow_target_manager_registered gauge
sparrow_target_manager_registered 0
```

Deregistration wasn't tested in an e2e setting, as deregistration only happens upon shutdown -> the metric isn't exposed anymore. I didn't start a local prometheus just to check whether the last state would've parsed. Additionally, as there is no guarantee that the last state of the metric will be parsed from prometheus, I don't know how one can easily test this scenario without some complicated setup :)

<!-- Explain what tests you've done and if your tests worked -->

- [x] Unit tests succeeded
- [x] E2E tests succeeded


## TODO

- [x] I've assigned this PR to myself
- [x] I've labeled this PR correctly

<!-- Add open ToDo's to this checklist -->