### PR TITLE
fix: linting issues with new golangci-lint version

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -113,23 +113,8 @@ linters:
       - linters:
           - mnd
           - revive
+          - goconst
         path: _test\.go
-      - path: pkg/golinters/errcheck.go
-        text: 'SA1019: errCfg.Exclude is deprecated: use ExcludeFunctions instead'
-      - path: pkg/commands/run.go
-        text: 'SA1019: lsc.Errcheck.Exclude is deprecated: use ExcludeFunctions instead'
-      - path: pkg/commands/run.go
-        text: 'SA1019: e.cfg.Run.Deadline is deprecated: Deadline exists for historical compatibility and should not be used.'
-      - path: pkg/golinters/gofumpt.go
-        text: 'SA1019: settings.LangVersion is deprecated: use the global `run.go` instead.'
-      - path: pkg/golinters/staticcheck_common.go
-        text: 'SA1019: settings.GoVersion is deprecated: use the global `run.go` instead.'
-      - path: pkg/lint/lintersdb/manager.go
-        text: 'SA1019: (.+).(GoVersion|LangVersion) is deprecated: use the global `run.go` instead.'
-      - path: pkg/golinters/unused.go
-        text: 'rangeValCopy: each iteration copies 160 bytes \(consider pointers or indexing\)'
-      - path: test/(fix|linters)_test.go
-        text: string `gocritic.go` has 3 occurrences, make it a constant
     paths:
       - third_party$
       - builtin$

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -13,6 +13,22 @@ import (
 	"time"
 )
 
+const (
+	// formatText is the text format for logging
+	formatText = "TEXT"
+	// formatJSON is the JSON format for logging
+	formatJSON = "JSON"
+
+	// levelDebug is the debug log level
+	levelDebug = "DEBUG"
+	// levelInfo is the info log level
+	levelInfo = "INFO"
+	// levelWarn is the warn log level
+	levelWarn = "WARN"
+	// levelError is the error log level
+	levelError = "ERROR"
+)
+
 type logger struct{}
 
 // NewLogger creates a new slog.Logger instance.
@@ -74,7 +90,7 @@ func newHandler() slog.Handler {
 		Level:     getLevel(os.Getenv("LOG_LEVEL")),
 	}
 
-	if strings.ToUpper(os.Getenv("LOG_FORMAT")) == "TEXT" {
+	if strings.ToUpper(os.Getenv("LOG_FORMAT")) == formatText {
 		opts.ReplaceAttr = func(_ []string, a slog.Attr) slog.Attr {
 			if a.Key == slog.TimeKey {
 				v := a.Value.Any().(time.Time)
@@ -92,13 +108,13 @@ func newHandler() slog.Handler {
 // Returns the level if no mapped level is found it returns info level
 func getLevel(level string) slog.Level {
 	switch strings.ToUpper(level) {
-	case "DEBUG":
+	case levelDebug:
 		return slog.LevelDebug
-	case "INFO":
+	case levelInfo:
 		return slog.LevelInfo
-	case "WARN", "WARNING":
+	case levelWarn, "WARNING":
 		return slog.LevelWarn
-	case "ERROR":
+	case levelError:
 		return slog.LevelError
 	default:
 		return slog.LevelInfo

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -158,7 +158,7 @@ func TestMiddleware(t *testing.T) {
 				}
 			})
 
-			req := httptest.NewRequest("GET", "/", http.NoBody)
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", http.NoBody)
 			w := httptest.NewRecorder()
 
 			middleware(handler).ServeHTTP(w, req)
@@ -181,19 +181,19 @@ func TestNewHandler(t *testing.T) {
 		},
 		{
 			name:      "Text handler with custom log level",
-			format:    "TEXT",
-			level:     "DEBUG",
+			format:    formatText,
+			level:     levelDebug,
 			wantLevel: slog.LevelDebug,
 		},
 		{
 			name:      "JSON handler with custom log level",
-			format:    "JSON",
-			level:     "WARN",
+			format:    formatJSON,
+			level:     levelWarn,
 			wantLevel: slog.LevelWarn,
 		},
 		{
 			name:      "Invalid log level",
-			format:    "TEXT",
+			format:    formatText,
 			level:     "UNKNOWN",
 			wantLevel: slog.LevelInfo,
 		},
@@ -206,7 +206,7 @@ func TestNewHandler(t *testing.T) {
 
 			handler := newHandler()
 
-			if tt.format == "TEXT" {
+			if tt.format == formatText {
 				if _, ok := handler.(*slog.TextHandler); !ok {
 					t.Errorf("Expected handler to be of type *log.Logger")
 				}
@@ -216,7 +216,7 @@ func TestNewHandler(t *testing.T) {
 				}
 			}
 
-			ok := handler.Enabled(context.Background(), tt.wantLevel)
+			ok := handler.Enabled(t.Context(), tt.wantLevel)
 			if !ok {
 				t.Errorf("Expected log level: %v", tt.wantLevel)
 			}
@@ -231,11 +231,11 @@ func TestGetLevel(t *testing.T) {
 		want  slog.Level
 	}{
 		{"Empty string", "", slog.LevelInfo},
-		{"Debug level", "DEBUG", slog.LevelDebug},
-		{"Info level", "INFO", slog.LevelInfo},
-		{"Warn level", "WARN", slog.LevelWarn},
+		{"Debug level", levelDebug, slog.LevelDebug},
+		{"Info level", levelInfo, slog.LevelInfo},
+		{"Warn level", levelWarn, slog.LevelWarn},
 		{"Warning level", "WARNING", slog.LevelWarn},
-		{"Error level", "ERROR", slog.LevelError},
+		{"Error level", levelError, slog.LevelError},
 		{"Invalid level", "UNKNOWN", slog.LevelInfo},
 	}
 

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -42,7 +42,7 @@ func TestAPI_Run(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			a := api{
 				server: &http.Server{Addr: ":8080"}, //nolint:gosec // irrelevant
 				router: chi.NewRouter(),
@@ -59,7 +59,7 @@ func TestAPI_Run(t *testing.T) {
 			}()
 			time.Sleep(10 * time.Millisecond)
 			if !tt.wantErr {
-				req := httptest.NewRequest(tt.want.method, tt.want.path, http.NoBody)
+				req := httptest.NewRequestWithContext(ctx, tt.want.method, tt.want.path, http.NoBody)
 				rec := httptest.NewRecorder()
 				a.router.ServeHTTP(rec, req)
 
@@ -167,7 +167,7 @@ func TestAPI_RegisterRoutes(t *testing.T) {
 
 			if !tt.wantErr {
 				for _, req := range tt.want {
-					request := httptest.NewRequest(req.method, req.path, http.NoBody)
+					request := httptest.NewRequestWithContext(t.Context(), req.method, req.path, http.NoBody)
 					recorder := httptest.NewRecorder()
 
 					a.router.ServeHTTP(recorder, request)

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -52,10 +52,9 @@ func TestAPI_Run(t *testing.T) {
 				t.Fatalf("Failed to register routes: %v", err)
 			}
 
+			errCh := make(chan error, 1)
 			go func() {
-				if err := a.Run(ctx); (err != nil) != tt.wantErr {
-					t.Errorf("Run() error = %v, wantErr %v", err, tt.wantErr)
-				}
+				errCh <- a.Run(ctx)
 			}()
 			time.Sleep(10 * time.Millisecond)
 			if !tt.wantErr {
@@ -70,12 +69,15 @@ func TestAPI_Run(t *testing.T) {
 				defer func() {
 					err := rec.Result().Body.Close()
 					if err != nil {
-						t.Fatalf("Failed to close recoder body")
+						t.Fatalf("Failed to close recorder body")
 					}
 				}()
 				if err := a.Shutdown(ctx); err != nil {
 					t.Fatalf("Failed to shutdown api: %v", err)
 				}
+			}
+			if err := <-errCh; (err != nil) != tt.wantErr {
+				t.Errorf("Run() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/pkg/checks/base.go
+++ b/pkg/checks/base.go
@@ -14,6 +14,9 @@ import (
 	"github.com/telekom/sparrow/internal/helper"
 )
 
+// LabelTarget is the name of the label used by checks for the target of a check run
+const LabelTarget = "target"
+
 // DefaultRetry provides a default configuration for the retry mechanism
 var DefaultRetry = helper.RetryConfig{
 	Count: 3,

--- a/pkg/checks/dns/metrics.go
+++ b/pkg/checks/dns/metrics.go
@@ -9,6 +9,13 @@ import (
 	"github.com/telekom/sparrow/pkg/checks"
 )
 
+const (
+	statusMetric    = "sparrow_dns_status"
+	durationMetric  = "sparrow_dns_duration_seconds"
+	countMetric     = "sparrow_dns_check_count"
+	histogramMetric = "sparrow_dns_duration"
+)
+
 // metrics defines the metric collectors of the DNS check
 type metrics struct {
 	status    *prometheus.GaugeVec
@@ -22,31 +29,31 @@ func newMetrics() metrics {
 	return metrics{
 		status: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "sparrow_dns_status",
+				Name: statusMetric,
 				Help: "Specifies if the target can be resolved.",
 			},
-			[]string{"target"},
+			[]string{checks.LabelTarget},
 		),
 		duration: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "sparrow_dns_duration_seconds",
+				Name: durationMetric,
 				Help: "Duration of DNS resolution attempts in seconds.",
 			},
-			[]string{"target"},
+			[]string{checks.LabelTarget},
 		),
 		count: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "sparrow_dns_check_count",
+				Name: countMetric,
 				Help: "Total number of DNS checks performed on the target and if they were successful.",
 			},
-			[]string{"target"},
+			[]string{checks.LabelTarget},
 		),
 		histogram: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
-				Name: "sparrow_dns_duration",
+				Name: histogramMetric,
 				Help: "Histogram of response times for DNS checks in seconds.",
 			},
-			[]string{"target"},
+			[]string{checks.LabelTarget},
 		),
 	}
 }

--- a/pkg/checks/dns/metrics_test.go
+++ b/pkg/checks/dns/metrics_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/telekom/sparrow/pkg/checks"
 )
 
 func TestMetrics_GetCollectors(t *testing.T) {
@@ -24,31 +25,31 @@ func TestMetrics_GetCollectors(t *testing.T) {
 			metrics: metrics{
 				status: prometheus.NewGaugeVec(
 					prometheus.GaugeOpts{
-						Name: "sparrow_dns_status",
+						Name: statusMetric,
 						Help: "Specifies if the target can be resolved.",
 					},
-					[]string{"target"},
+					[]string{checks.LabelTarget},
 				),
 				duration: prometheus.NewGaugeVec(
 					prometheus.GaugeOpts{
-						Name: "sparrow_dns_duration",
+						Name: durationMetric,
 						Help: "Duration of DNS resolution attempts in seconds.",
 					},
-					[]string{"target"},
+					[]string{checks.LabelTarget},
 				),
 				count: prometheus.NewCounterVec(
 					prometheus.CounterOpts{
-						Name: "sparrow_dns_check_count",
+						Name: countMetric,
 						Help: "Total number of DNS checks performed on the target and if they were successful.",
 					},
-					[]string{"target"},
+					[]string{checks.LabelTarget},
 				),
 				histogram: prometheus.NewHistogramVec(
 					prometheus.HistogramOpts{
-						Name: "sparrow_dns_duration",
+						Name: histogramMetric,
 						Help: "Histogram of response times for DNS checks in seconds.",
 					},
-					[]string{"target"},
+					[]string{checks.LabelTarget},
 				),
 			},
 		},

--- a/pkg/checks/health/health.go
+++ b/pkg/checks/health/health.go
@@ -21,12 +21,17 @@ import (
 	"github.com/telekom/sparrow/pkg/checks"
 )
 
+const (
+	stateUnhealthy = "unhealthy"
+	stateHealthy   = "healthy"
+)
+
 var (
 	_            checks.Check   = (*Health)(nil)
 	_            checks.Runtime = (*Config)(nil)
 	stateMapping                = map[int]string{
-		0: "unhealthy",
-		1: "healthy",
+		0: stateUnhealthy,
+		1: stateHealthy,
 	}
 )
 
@@ -219,7 +224,7 @@ func getHealth(ctx context.Context, client *http.Client, url string) error {
 		return err
 	}
 
-	resp, err := client.Do(req) //nolint:bodyclose,gosec // Closed in defer below; URL is operator-configured
+	resp, err := client.Do(req) //nolint:bodyclose // Closed in defer below
 	if err != nil {
 		log.Error("Error while requesting health", "error", err)
 		return err

--- a/pkg/checks/health/health_test.go
+++ b/pkg/checks/health/health_test.go
@@ -208,7 +208,8 @@ func TestHealth_Check(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			for endpoint, statuscode := range tt.registeredEndpoints {
-				httpmock.RegisterResponder(http.MethodGet, endpoint,
+				httpmock.RegisterResponder(
+					http.MethodGet, endpoint,
 					httpmock.NewStringResponder(statuscode, ""),
 				)
 			}

--- a/pkg/checks/health/metrics.go
+++ b/pkg/checks/health/metrics.go
@@ -22,9 +22,7 @@ func newMetrics() metrics {
 				Name: "sparrow_health_up",
 				Help: "Health of targets",
 			},
-			[]string{
-				"target",
-			},
+			[]string{checks.LabelTarget},
 		),
 	}
 }

--- a/pkg/checks/latency/latency.go
+++ b/pkg/checks/latency/latency.go
@@ -230,8 +230,7 @@ func getLatency(ctx context.Context, c *http.Client, url string) (result, error)
 	}
 
 	start := time.Now()
-	//nolint:bodyclose,gosec // Closed in defer below, and gosec g704 is not relevant because the url is parsed and validated in the config validation
-	resp, err := c.Do(req)
+	resp, err := c.Do(req) //nolint:bodyclose // Closed in defer below
 	if err != nil {
 		log.Error("Error while checking latency", "error", err)
 		errval := err.Error()

--- a/pkg/checks/latency/metrics.go
+++ b/pkg/checks/latency/metrics.go
@@ -24,42 +24,36 @@ func newMetrics() metrics {
 				Name: "sparrow_latency_seconds",
 				Help: "Latency for each target",
 			},
-			[]string{
-				"target",
-			},
+			[]string{checks.LabelTarget},
 		),
 		count: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "sparrow_latency_count",
 				Help: "Count of latency checks done",
 			},
-			[]string{
-				"target",
-			},
+			[]string{checks.LabelTarget},
 		),
 		histogram: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
 				Name: "sparrow_latency_duration",
 				Help: "Latency of targets in seconds",
 			},
-			[]string{
-				"target",
-			},
+			[]string{checks.LabelTarget},
 		),
 	}
 }
 
 // Remove removes the metrics which have the passed target as a label
 func (m metrics) Remove(label string) error {
-	if !m.totalDuration.Delete(map[string]string{"target": label}) {
+	if !m.totalDuration.Delete(map[string]string{checks.LabelTarget: label}) {
 		return checks.ErrMetricNotFound{Label: label}
 	}
 
-	if !m.count.Delete(map[string]string{"target": label}) {
+	if !m.count.Delete(map[string]string{checks.LabelTarget: label}) {
 		return checks.ErrMetricNotFound{Label: label}
 	}
 
-	if !m.histogram.Delete(map[string]string{"target": label}) {
+	if !m.histogram.Delete(map[string]string{checks.LabelTarget: label}) {
 		return checks.ErrMetricNotFound{Label: label}
 	}
 

--- a/pkg/checks/traceroute/metrics.go
+++ b/pkg/checks/traceroute/metrics.go
@@ -12,10 +12,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-const (
-	labelTarget = "target"
-)
-
 type metrics struct {
 	minHops       *prometheus.GaugeVec
 	checkDuration *prometheus.GaugeVec
@@ -30,12 +26,12 @@ func (m metrics) List() []prometheus.Collector {
 
 func (m metrics) MinHops(data map[string]result) {
 	for target, hops := range data {
-		m.minHops.With(prometheus.Labels{labelTarget: target}).Set(float64(hops.MinHops))
+		m.minHops.With(prometheus.Labels{checks.LabelTarget: target}).Set(float64(hops.MinHops))
 	}
 }
 
 func (m metrics) CheckDuration(target string, n time.Duration) {
-	m.checkDuration.With(prometheus.Labels{labelTarget: target}).Set(float64(n.Milliseconds()))
+	m.checkDuration.With(prometheus.Labels{checks.LabelTarget: target}).Set(float64(n.Milliseconds()))
 }
 
 func newMetrics() metrics {
@@ -43,11 +39,11 @@ func newMetrics() metrics {
 		minHops: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: "sparrow_traceroute",
 			Name:      "minimum_hops",
-		}, []string{labelTarget}),
+		}, []string{checks.LabelTarget}),
 		checkDuration: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: "sparrow_traceroute",
 			Name:      "check_duration_ms",
-		}, []string{labelTarget}),
+		}, []string{checks.LabelTarget}),
 	}
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,9 +34,16 @@ type Config struct {
 	Telemetry metrics.Config `yaml:"telemetry" mapstructure:"telemetry"`
 }
 
+type LoaderType string
+
+const (
+	loaderHTTP LoaderType = "http"
+	loaderFile LoaderType = "file"
+)
+
 // LoaderConfig is the configuration for loader
 type LoaderConfig struct {
-	Type     string           `yaml:"type" mapstructure:"type"`
+	Type     LoaderType       `yaml:"type" mapstructure:"type"`
 	Interval time.Duration    `yaml:"interval" mapstructure:"interval"`
 	Http     HttpLoaderConfig `yaml:"http" mapstructure:"http"`
 	File     FileLoaderConfig `yaml:"file" mapstructure:"file"`

--- a/pkg/config/file_test.go
+++ b/pkg/config/file_test.go
@@ -42,7 +42,7 @@ func TestFileLoader_Run(t *testing.T) {
 		{
 			name: "Loads config from file",
 			config: LoaderConfig{
-				Type:     "file",
+				Type:     loaderFile,
 				Interval: 1 * time.Second,
 				File: FileLoaderConfig{
 					Path: "test/data/config.yaml",
@@ -60,7 +60,7 @@ func TestFileLoader_Run(t *testing.T) {
 		{
 			name: "Continuous loading disabled",
 			config: LoaderConfig{
-				Type:     "file",
+				Type:     loaderFile,
 				Interval: 0,
 				File: FileLoaderConfig{
 					Path: "test/data/config.yaml",
@@ -115,7 +115,7 @@ func TestFileLoader_getRuntimeConfig(t *testing.T) {
 		{
 			name: "Invalid File Path",
 			config: LoaderConfig{
-				Type:     "file",
+				Type:     loaderFile,
 				Interval: 1 * time.Second,
 				File: FileLoaderConfig{
 					Path: "test/data/nonexistent.yaml",
@@ -126,7 +126,7 @@ func TestFileLoader_getRuntimeConfig(t *testing.T) {
 		{
 			name: "Malformed Config File",
 			config: LoaderConfig{
-				Type:     "file",
+				Type:     loaderFile,
 				Interval: 1 * time.Second,
 				File: FileLoaderConfig{
 					Path: "test/data/malformed.yaml",
@@ -145,7 +145,7 @@ func TestFileLoader_getRuntimeConfig(t *testing.T) {
 		{
 			name: "Failed to close file",
 			config: LoaderConfig{
-				Type:     "file",
+				Type:     loaderFile,
 				Interval: 1 * time.Second,
 				File: FileLoaderConfig{
 					Path: "test/data/valid.yaml",
@@ -153,7 +153,7 @@ func TestFileLoader_getRuntimeConfig(t *testing.T) {
 			},
 			mockFS: func(t *testing.T) fs.FS {
 				b, err := yaml.Marshal(LoaderConfig{
-					Type:     "file",
+					Type:     loaderFile,
 					Interval: 1 * time.Second,
 					File: FileLoaderConfig{
 						Path: "test/data/valid.yaml",
@@ -179,7 +179,7 @@ func TestFileLoader_getRuntimeConfig(t *testing.T) {
 		{
 			name: "Malformed config file and failed to close file",
 			config: LoaderConfig{
-				Type:     "file",
+				Type:     loaderFile,
 				Interval: 1 * time.Second,
 				File: FileLoaderConfig{
 					Path: "test/data/malformed.yaml",

--- a/pkg/config/http.go
+++ b/pkg/config/http.go
@@ -99,7 +99,7 @@ func (hl *HttpLoader) getRuntimeConfig(ctx context.Context) (cfg runtime.Config,
 		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", hl.cfg.Http.Token))
 	}
 
-	res, err := hl.client.Do(req) //nolint:bodyclose,gosec // Closed in defer below; URL is operator-configured
+	res, err := hl.client.Do(req) //nolint:bodyclose // Closed in defer below
 	if err != nil {
 		log.Error("Http get request failed", "error", err.Error())
 		return cfg, err

--- a/pkg/config/http_test.go
+++ b/pkg/config/http_test.go
@@ -43,7 +43,7 @@ func TestHttpLoader_GetRuntimeConfig(t *testing.T) {
 			name: "Get runtime configuration",
 			cfg: &Config{
 				Loader: LoaderConfig{
-					Type:     "http",
+					Type:     loaderHTTP,
 					Interval: 1 * time.Second,
 				},
 			},
@@ -63,7 +63,7 @@ func TestHttpLoader_GetRuntimeConfig(t *testing.T) {
 			name: "Get runtime configuration with auth",
 			cfg: &Config{
 				Loader: LoaderConfig{
-					Type:     "http",
+					Type:     loaderHTTP,
 					Interval: time.Second,
 					Http: HttpLoaderConfig{
 						Token: "SECRET",
@@ -86,7 +86,7 @@ func TestHttpLoader_GetRuntimeConfig(t *testing.T) {
 			name: "Get runtime configuration with statuscode 400",
 			cfg: &Config{
 				Loader: LoaderConfig{
-					Type:     "http",
+					Type:     loaderHTTP,
 					Interval: time.Second,
 				},
 			},
@@ -100,7 +100,8 @@ func TestHttpLoader_GetRuntimeConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			endpoint := "https://api.test.com/test"
-			httpmock.RegisterResponder(http.MethodGet, endpoint,
+			httpmock.RegisterResponder(
+				http.MethodGet, endpoint,
 				func(req *http.Request) (*http.Response, error) {
 					if tt.cfg.Loader.Http.Token != "" {
 						require.Equal(t, req.Header.Get("Authorization"), fmt.Sprintf("Bearer %s", tt.cfg.Loader.Http.Token))
@@ -200,7 +201,7 @@ func TestHttpLoader_Run(t *testing.T) {
 
 			hl := &HttpLoader{
 				cfg: LoaderConfig{
-					Type:     "http",
+					Type:     loaderHTTP,
 					Interval: tt.interval,
 					Http: HttpLoaderConfig{
 						Url: "https://api.test.com/test",
@@ -289,7 +290,7 @@ func TestHttpLoader_Run_config_sent_to_channel(t *testing.T) {
 
 	hl := &HttpLoader{
 		cfg: LoaderConfig{
-			Type:     "http",
+			Type:     loaderHTTP,
 			Interval: time.Millisecond * 500,
 			Http: HttpLoaderConfig{
 				Url: "https://api.test.com/test",
@@ -345,7 +346,7 @@ func TestHttpLoader_Run_empty_config_sent_to_channel_500(t *testing.T) {
 
 	hl := &HttpLoader{
 		cfg: LoaderConfig{
-			Type:     "http",
+			Type:     loaderHTTP,
 			Interval: time.Millisecond * 500,
 			Http: HttpLoaderConfig{
 				Url: "https://api.test.com/test",
@@ -392,7 +393,7 @@ func TestHttpLoader_Run_empty_config_sent_to_channel_client_error(t *testing.T) 
 
 	hl := &HttpLoader{
 		cfg: LoaderConfig{
-			Type:     "http",
+			Type:     loaderHTTP,
 			Interval: time.Millisecond * 500,
 			Http: HttpLoaderConfig{
 				Url: "https://api.test.com/test",

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -25,7 +25,7 @@ type Loader interface {
 // NewLoader Get a new typed runtime configuration loader
 func NewLoader(cfg *Config, cRuntime chan<- runtime.Config) Loader {
 	switch cfg.Loader.Type {
-	case "http":
+	case loaderHTTP:
 		return NewHttpLoader(cfg, cRuntime)
 	default:
 		return NewFileLoader(cfg, cRuntime)

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -62,7 +62,7 @@ func (c *LoaderConfig) Validate(ctx context.Context) error {
 	}
 
 	switch c.Type {
-	case "http":
+	case loaderHTTP:
 		if _, err := url.ParseRequestURI(c.Http.Url); err != nil {
 			log.Error("The loader http url is not a valid url")
 			return ErrInvalidLoaderHttpURL
@@ -71,7 +71,7 @@ func (c *LoaderConfig) Validate(ctx context.Context) error {
 			log.Error("The amount of loader http retries should be above 0 and below 6", "retryCount", c.Http.RetryCfg.Count)
 			return ErrInvalidLoaderHttpRetryCount
 		}
-	case "file":
+	case loaderFile:
 		if c.File.Path == "" {
 			log.Error("The loader file path cannot be empty")
 			return ErrInvalidLoaderFilePath

--- a/pkg/config/validate_test.go
+++ b/pkg/config/validate_test.go
@@ -29,7 +29,7 @@ func TestConfig_Validate(t *testing.T) {
 					ListeningAddress: ":8080",
 				},
 				Loader: LoaderConfig{
-					Type: "http",
+					Type: loaderHTTP,
 					Http: HttpLoaderConfig{
 						Url:     "https://test.de/config",
 						Timeout: time.Second,
@@ -52,7 +52,7 @@ func TestConfig_Validate(t *testing.T) {
 				},
 				SparrowName: "sparrow.com",
 				Loader: LoaderConfig{
-					Type: "http",
+					Type: loaderHTTP,
 					Http: HttpLoaderConfig{
 						Url:     "",
 						Timeout: time.Second,
@@ -75,7 +75,7 @@ func TestConfig_Validate(t *testing.T) {
 				},
 				SparrowName: "sparrow.com",
 				Loader: LoaderConfig{
-					Type: "http",
+					Type: loaderHTTP,
 					Http: HttpLoaderConfig{
 						Url:     "this is not a valid url",
 						Timeout: time.Second,
@@ -97,7 +97,7 @@ func TestConfig_Validate(t *testing.T) {
 				},
 				SparrowName: "sparrow.com",
 				Loader: LoaderConfig{
-					Type: "http",
+					Type: loaderHTTP,
 					Http: HttpLoaderConfig{
 						Url:     "test.de",
 						Timeout: time.Minute,
@@ -119,7 +119,7 @@ func TestConfig_Validate(t *testing.T) {
 				},
 				SparrowName: "sparrow.com",
 				Loader: LoaderConfig{
-					Type: "file",
+					Type: loaderFile,
 					File: FileLoaderConfig{
 						Path: "",
 					},
@@ -136,7 +136,7 @@ func TestConfig_Validate(t *testing.T) {
 				},
 				SparrowName: "sparrow.com",
 				Loader: LoaderConfig{
-					Type: "file",
+					Type: loaderFile,
 					File: FileLoaderConfig{
 						Path: "",
 					},

--- a/pkg/sparrow/controller.go
+++ b/pkg/sparrow/controller.go
@@ -155,6 +155,8 @@ func (cc *ChecksController) UnregisterCheck(ctx context.Context, check checks.Ch
 	cc.checks.Delete(check)
 }
 
+const applicationJSON = "application/json"
+
 var oapiBoilerplate = openapi3.T{
 	// this object should probably be user defined
 	OpenAPI: "3.0.0",
@@ -196,7 +198,7 @@ func (cc *ChecksController) GenerateCheckSpecs(ctx context.Context) (openapi3.T,
 		responses.Set(fmt.Sprint(http.StatusOK), &openapi3.ResponseRef{
 			Value: &openapi3.Response{
 				Description: &bodyDesc,
-				Content:     openapi3.NewContentWithSchemaRef(ref, []string{"application/json"}),
+				Content:     openapi3.NewContentWithSchemaRef(ref, []string{applicationJSON}),
 			},
 		})
 		doc.Paths.Set(fmt.Sprintf("/v1/metrics/%s", name), &openapi3.PathItem{

--- a/pkg/sparrow/handlers.go
+++ b/pkg/sparrow/handlers.go
@@ -68,9 +68,9 @@ func (s *Sparrow) handleOpenAPI(w http.ResponseWriter, r *http.Request) {
 
 	var marshaler encoder
 	switch mime {
-	case "application/json":
+	case applicationJSON:
 		marshaler = json.NewEncoder(w)
-		w.Header().Add("Content-Type", "application/json")
+		w.Header().Add("Content-Type", applicationJSON)
 	default:
 		marshaler = yaml.NewEncoder(w)
 		w.Header().Add("Content-Type", "text/yaml")
@@ -121,5 +121,5 @@ func (s *Sparrow) handleCheckMetrics(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	w.Header().Add("Content-Type", "application/json")
+	w.Header().Add("Content-Type", applicationJSON)
 }

--- a/pkg/sparrow/handlers_test.go
+++ b/pkg/sparrow/handlers_test.go
@@ -43,15 +43,15 @@ func TestSparrow_handleOpenAPI(t *testing.T) {
 	}
 
 	tests := []test{
-		{name: "yaml is default", args: args{request: httptest.NewRequest(http.MethodGet, "/openapi.yaml", bytes.NewBuffer([]byte{})), response: httptest.NewRecorder(), headers: map[string]string{}}, decoder: func(rr *httptest.ResponseRecorder) error {
+		{name: "yaml is default", args: args{request: httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/openapi.yaml", bytes.NewBuffer([]byte{})), response: httptest.NewRecorder(), headers: map[string]string{}}, decoder: func(rr *httptest.ResponseRecorder) error {
 			b := rr.Body.Bytes()
 			return yaml.Unmarshal(b, &openapi3.T{})
 		}},
-		{name: "set json via accept header", args: args{request: httptest.NewRequest(http.MethodGet, "/openapi.yaml", bytes.NewBuffer([]byte{})), response: httptest.NewRecorder(), headers: map[string]string{"Accept": "application/json"}}, decoder: func(rr *httptest.ResponseRecorder) error {
+		{name: "set json via accept header", args: args{request: httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/openapi.yaml", bytes.NewBuffer([]byte{})), response: httptest.NewRecorder(), headers: map[string]string{"Accept": applicationJSON}}, decoder: func(rr *httptest.ResponseRecorder) error {
 			b := rr.Body.Bytes()
 			return json.Unmarshal(b, &openapi3.T{})
 		}},
-		{name: "set yaml via accept header", args: args{request: httptest.NewRequest(http.MethodGet, "/openapi.yaml", bytes.NewBuffer([]byte{})), response: httptest.NewRecorder(), headers: map[string]string{"Accept": "text/yaml"}}, decoder: func(rr *httptest.ResponseRecorder) error {
+		{name: "set yaml via accept header", args: args{request: httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/openapi.yaml", bytes.NewBuffer([]byte{})), response: httptest.NewRecorder(), headers: map[string]string{"Accept": "text/yaml"}}, decoder: func(rr *httptest.ResponseRecorder) error {
 			b := rr.Body.Bytes()
 			return yaml.Unmarshal(b, &openapi3.T{})
 		}},
@@ -109,9 +109,9 @@ func TestSparrow_handleCheckMetrics(t *testing.T) {
 			}
 
 			w := httptest.NewRecorder()
-			r := chiRequest(httptest.NewRequest(http.MethodGet, "/v1/metrics/alpha", bytes.NewBuffer([]byte{})), "alpha")
+			r := chiRequest(httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v1/metrics/alpha", bytes.NewBuffer([]byte{})), "alpha")
 			if tt.wantCode == http.StatusBadRequest {
-				r = chiRequest(httptest.NewRequest(http.MethodGet, "/v1/metrics/", bytes.NewBuffer([]byte{})), "")
+				r = chiRequest(httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v1/metrics/", bytes.NewBuffer([]byte{})), "")
 			}
 
 			s.handleCheckMetrics(w, r)

--- a/pkg/sparrow/metrics/instance_info_test.go
+++ b/pkg/sparrow/metrics/instance_info_test.go
@@ -102,7 +102,7 @@ func assertMetricsContainLabels(t *testing.T, metrics []*io_prometheus_client.Me
 
 		assert.Len(t, mf.GetMetric(), 1, "expected exactly one metric")
 
-		const wantVal = 1
+		const wantVal float64 = 1
 		for _, m := range mf.GetMetric() {
 			assert.Equal(t, wantVal, m.GetGauge().GetValue(), "%q metric value expected %d", instanceInfoMetric, wantVal)
 

--- a/pkg/sparrow/metrics/metrics.go
+++ b/pkg/sparrow/metrics/metrics.go
@@ -62,7 +62,8 @@ func (m *manager) GetRegistry() *prometheus.Registry {
 // InitTracing initializes the OpenTelemetry tracing
 func (m *manager) InitTracing(ctx context.Context) error {
 	log := logger.FromContext(ctx)
-	res, err := resource.New(ctx,
+	res, err := resource.New(
+		ctx,
 		resource.WithHost(),
 		resource.WithContainer(),
 		resource.WithAttributes(
@@ -87,7 +88,8 @@ func (m *manager) InitTracing(ctx context.Context) error {
 		maxQueueSize = 1000
 		maxBatchSize = 100
 	)
-	bsp := sdktrace.NewBatchSpanProcessor(exporter,
+	bsp := sdktrace.NewBatchSpanProcessor(
+		exporter,
 		sdktrace.WithBatchTimeout(batchTimeout),
 		sdktrace.WithMaxQueueSize(maxQueueSize),
 		sdktrace.WithMaxExportBatchSize(maxBatchSize),

--- a/pkg/sparrow/targets/remote/gitlab/gitlab.go
+++ b/pkg/sparrow/targets/remote/gitlab/gitlab.go
@@ -105,7 +105,8 @@ func (c *client) fetchFile(ctx context.Context, f string) (checks.GlobalTarget, 
 		log.ErrorContext(ctx, "Could not parse GitLab API file URL", "url", u, "error", err)
 		return res, err
 	}
-	req, err := http.NewRequestWithContext(ctx,
+	req, err := http.NewRequestWithContext(
+		ctx,
 		http.MethodGet,
 		u.String(),
 		http.NoBody,
@@ -120,7 +121,7 @@ func (c *client) fetchFile(ctx context.Context, f string) (checks.GlobalTarget, 
 	query.Add("ref", c.config.Branch)
 	req.URL.RawQuery = query.Encode()
 
-	resp, err := c.client.Do(req) //nolint:gosec // URL is operator-configured GitLab base URL
+	resp, err := c.client.Do(req)
 	if err != nil {
 		log.ErrorContext(ctx, "Failed to fetch file", "error", err)
 		return res, err
@@ -186,7 +187,7 @@ func (c *client) fetchNextFileList(ctx context.Context, reqUrl string) ([]string
 	req.Header.Add("PRIVATE-TOKEN", c.config.Token)
 	req.Header.Add("Content-Type", "application/json")
 
-	resp, err := c.client.Do(req) //nolint:gosec // URL is operator-configured GitLab base URL
+	resp, err := c.client.Do(req)
 	if err != nil {
 		log.ErrorContext(ctx, "Failed to fetch file list", "error", err)
 		return nil, err
@@ -241,7 +242,8 @@ func (c *client) PutFile(ctx context.Context, file remote.File) error { //nolint
 		log.ErrorContext(ctx, "Failed to create request", "error", err)
 		return err
 	}
-	req, err := http.NewRequestWithContext(ctx,
+	req, err := http.NewRequestWithContext(
+		ctx,
 		http.MethodPut,
 		fmt.Sprintf("%s/api/v4/projects/%d/repository/files/%s", c.config.BaseURL, c.config.ProjectID, n),
 		bytes.NewBuffer(b),
@@ -254,7 +256,7 @@ func (c *client) PutFile(ctx context.Context, file remote.File) error { //nolint
 	req.Header.Add("PRIVATE-TOKEN", c.config.Token)
 	req.Header.Add("Content-Type", "application/json")
 
-	resp, err := c.client.Do(req) //nolint:gosec // URL is operator-configured GitLab base URL
+	resp, err := c.client.Do(req)
 	if err != nil {
 		log.ErrorContext(ctx, "Failed to push registration file", "error", err)
 		return err
@@ -285,7 +287,8 @@ func (c *client) PostFile(ctx context.Context, file remote.File) error { //nolin
 		log.ErrorContext(ctx, "Failed to create request", "error", err)
 		return err
 	}
-	req, err := http.NewRequestWithContext(ctx,
+	req, err := http.NewRequestWithContext(
+		ctx,
 		http.MethodPost,
 		fmt.Sprintf("%s/api/v4/projects/%d/repository/files/%s", c.config.BaseURL, c.config.ProjectID, n),
 		bytes.NewBuffer(b),
@@ -298,7 +301,7 @@ func (c *client) PostFile(ctx context.Context, file remote.File) error { //nolin
 	req.Header.Add("PRIVATE-TOKEN", c.config.Token)
 	req.Header.Add("Content-Type", "application/json")
 
-	resp, err := c.client.Do(req) //nolint:gosec // URL is operator-configured GitLab base URL
+	resp, err := c.client.Do(req)
 	if err != nil {
 		log.ErrorContext(ctx, "Failed to post file", "error", err)
 		return err
@@ -332,7 +335,8 @@ func (c *client) DeleteFile(ctx context.Context, file remote.File) error { //nol
 		return err
 	}
 
-	req, err := http.NewRequestWithContext(ctx,
+	req, err := http.NewRequestWithContext(
+		ctx,
 		http.MethodDelete,
 		fmt.Sprintf("%s/api/v4/projects/%d/repository/files/%s", c.config.BaseURL, c.config.ProjectID, n),
 		bytes.NewBuffer(b),
@@ -345,7 +349,7 @@ func (c *client) DeleteFile(ctx context.Context, file remote.File) error { //nol
 	req.Header.Add("PRIVATE-TOKEN", c.config.Token)
 	req.Header.Add("Content-Type", "application/json")
 
-	resp, err := c.client.Do(req) //nolint:gosec // URL is operator-configured GitLab base URL
+	resp, err := c.client.Do(req)
 	if err != nil {
 		log.ErrorContext(ctx, "Failed to delete file", "error", err)
 		return err
@@ -380,7 +384,8 @@ func (c *client) fetchDefaultBranch() string {
 	log := logger.FromContext(ctx).With("gitlab", c.config.BaseURL)
 
 	log.DebugContext(ctx, "No branch configured, fetching default branch")
-	req, err := http.NewRequestWithContext(ctx,
+	req, err := http.NewRequestWithContext(
+		ctx,
 		http.MethodGet,
 		fmt.Sprintf("%s/api/v4/projects/%d/repository/branches", c.config.BaseURL, c.config.ProjectID),
 		http.NoBody,
@@ -393,7 +398,7 @@ func (c *client) fetchDefaultBranch() string {
 	req.Header.Add("PRIVATE-TOKEN", c.config.Token)
 	req.Header.Add("Content-Type", "application/json")
 
-	resp, err := c.client.Do(req) //nolint:gosec // URL is operator-configured GitLab base URL
+	resp, err := c.client.Do(req)
 	if err != nil {
 		log.ErrorContext(ctx, "Failed to fetch branches", "error", err)
 		return fallbackBranch

--- a/pkg/sparrow/targets/targetmanager.go
+++ b/pkg/sparrow/targets/targetmanager.go
@@ -13,6 +13,11 @@ import (
 	"github.com/telekom/sparrow/pkg/sparrow/targets/interactor"
 )
 
+const (
+	schemeHTTP  = "http"
+	schemeHTTPS = "https"
+)
+
 // TargetManager handles the management of globalTargets for
 // a Sparrow instance
 type TargetManager interface {
@@ -75,7 +80,7 @@ func (c *TargetManagerConfig) Validate(ctx context.Context) error {
 		return ErrInvalidUpdateInterval
 	}
 
-	if c.Scheme != "http" && c.Scheme != "https" {
+	if c.Scheme != schemeHTTP && c.Scheme != schemeHTTPS {
 		log.Error("The scheme should be either of: 'http', 'https'", "scheme", c.Scheme)
 		return ErrInvalidScheme
 	}

--- a/pkg/sparrow/targets/targetmanager_test.go
+++ b/pkg/sparrow/targets/targetmanager_test.go
@@ -25,7 +25,7 @@ func TestTargetManagerConfig_Validate(t *testing.T) {
 			cfg: TargetManagerConfig{
 				Type: "gitlab",
 				General: General{
-					Scheme:               "http",
+					Scheme:               schemeHTTP,
 					UnhealthyThreshold:   1 * time.Second,
 					CheckInterval:        1 * time.Second,
 					RegistrationInterval: 1 * time.Second,
@@ -38,7 +38,7 @@ func TestTargetManagerConfig_Validate(t *testing.T) {
 			cfg: TargetManagerConfig{
 				Type: "gitlab",
 				General: General{
-					Scheme:               "http",
+					Scheme:               schemeHTTP,
 					UnhealthyThreshold:   0,
 					CheckInterval:        1 * time.Second,
 					RegistrationInterval: 0,
@@ -51,7 +51,7 @@ func TestTargetManagerConfig_Validate(t *testing.T) {
 			cfg: TargetManagerConfig{
 				Type: "gitlab",
 				General: General{
-					Scheme:               "http",
+					Scheme:               schemeHTTP,
 					UnhealthyThreshold:   1 * time.Second,
 					CheckInterval:        0,
 					RegistrationInterval: 1 * time.Second,
@@ -65,7 +65,7 @@ func TestTargetManagerConfig_Validate(t *testing.T) {
 			cfg: TargetManagerConfig{
 				Type: "gitlab",
 				General: General{
-					Scheme:               "http",
+					Scheme:               schemeHTTP,
 					UnhealthyThreshold:   -1 * time.Second,
 					CheckInterval:        1 * time.Second,
 					RegistrationInterval: 1 * time.Second,
@@ -79,7 +79,7 @@ func TestTargetManagerConfig_Validate(t *testing.T) {
 			cfg: TargetManagerConfig{
 				Type: "unknown",
 				General: General{
-					Scheme:               "http",
+					Scheme:               schemeHTTP,
 					UnhealthyThreshold:   1 * time.Second,
 					CheckInterval:        1 * time.Second,
 					RegistrationInterval: 1 * time.Second,
@@ -120,7 +120,7 @@ func TestTargetManagerConfig_Validate(t *testing.T) {
 			cfg: TargetManagerConfig{
 				Type: "gitlab",
 				General: General{
-					Scheme:               "http",
+					Scheme:               schemeHTTP,
 					UnhealthyThreshold:   1 * time.Second,
 					CheckInterval:        1 * time.Second,
 					RegistrationInterval: 1 * time.Second,
@@ -134,7 +134,7 @@ func TestTargetManagerConfig_Validate(t *testing.T) {
 			cfg: TargetManagerConfig{
 				Type: "gitlab",
 				General: General{
-					Scheme:               "https",
+					Scheme:               schemeHTTPS,
 					UnhealthyThreshold:   1 * time.Second,
 					CheckInterval:        1 * time.Second,
 					RegistrationInterval: 1 * time.Second,


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 Deutsche Telekom IT GmbH

SPDX-License-Identifier: CC-BY-4.0
-->

## Motivation

<!-- Explain what motivated you to do these changes -->
To fix all the previously failing golangci-lint errors that came in with the latest golangci-lint version which enabled the `goconst` linter by default.

## Changes

Not many changes, besides adding a couple of constants to fix the linting errors and a type annotation for the instance info check tests of #391.

For additional information look at the commits.

## Tests done

<!-- Explain what tests you've done and if your tests worked -->

- [x] Unit tests succeeded
- [x] E2E tests succeeded

## TODO

- [x] I've assigned this PR to myself
- [x] I've labeled this PR correctly

<!-- Add open ToDo's to this checklist -->