### PR TITLE
feat: implement OIDC/WIF credential provider for S3 interactor

### DIFF
--- a/docs/s3-oidc-auth-design.md
+++ b/docs/s3-oidc-auth-design.md
@@ -1,0 +1,111 @@
+<!--
+SPDX-FileCopyrightText: 2025 Deutsche Telekom IT GmbH
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
+# Design: S3 OIDC Authentication via File-Based Token
+
+## Context
+
+Sparrow needs S3-compatible object storage as an alternative target backend
+to GitLab. Instances run on AWS, GCP, Azure, on-prem VMs (T-Cloud/OpenStack),
+and Kubernetes. Security policy requires keyless authentication via Workload
+Identity Federation (WIF) where available, with static credentials as fallback
+for on-prem environments.
+
+The S3 interactor uses [minio-go v7](https://github.com/minio/minio-go).
+OIDC auth works by exchanging a short-lived identity token for temporary S3
+credentials via AWS STS (or a compatible endpoint). The question is how
+sparrow should obtain that identity token.
+
+## Decision
+
+Use `tokenPath` (file-based token read) as the only OIDC token source.
+Do not implement `tokenURL` or `tokenHeaders` for direct IMDS HTTP calls.
+
+## Why Not a Generic `tokenURL` Fetcher
+
+IMDS endpoints are fundamentally incompatible across providers:
+
+| Cloud      | Token retrieval                                                  | Response format                                       |
+| ---------- | ---------------------------------------------------------------- | ----------------------------------------------------- |
+| AWS IMDSv2 | Two-step PUT then GET with session token header                  | JSON with `AccessKeyId` / `SecretAccessKey` / `Token` |
+| Azure      | Single GET with `Metadata: true` header, resource query param    | JSON `access_token` field                             |
+| GCP        | Single GET with `Metadata-Flavor: Google` header, audience param | Raw JWT string                                        |
+| Kubernetes | Projected volume file                                            | Raw JWT file                                          |
+
+A `tokenURL` + `tokenHeaders` abstraction would:
+
+- Hide provider-specific multi-step flows (AWS needs PUT before GET)
+- Require per-provider response parsing (JSON field vs. raw body)
+- Still not handle AWS IMDSv2 session token management correctly
+- Create a leaky abstraction that encourages misconfiguration
+
+## Why File-Based Tokens Work Universally
+
+Every platform has a well-established mechanism to project tokens to disk:
+
+- **Kubernetes (all clouds):** Projected service account token volumes —
+  a native K8s feature, no cloud dependency
+- **AWS EKS:** IRSA and EKS Pod Identity both write tokens to files
+- **Azure AKS:** The Workload Identity webhook projects tokens to the pod
+  filesystem automatically
+- **GCP GKE:** Workload Identity Federation via node metadata proxy
+  (transparent); file projection also works when needed
+- **VMs / on-prem:** A sidecar or cron job fetches from IMDS and writes to
+  a well-known path — an established ops pattern used by tools such as
+  `aws-vault`, `aad-pod-identity`, and custom scripts
+
+This pushes cloud-specific IMDS complexity to the operations layer, where
+teams already have domain expertise and tooling for their provider. Sparrow's
+code stays provider-agnostic: one `os.ReadFile` call, no HTTP client, no
+response parsing, no provider-specific headers.
+
+## Configuration
+
+```yaml
+targetManager:
+  type: s3
+  s3:
+    endpoint: s3.amazonaws.com
+    bucket: sparrow-targets
+    auth:
+      provider: oidc
+      oidc:
+        tokenPath: /var/run/secrets/tokens/sparrow
+        roleARN: arn:aws:iam::123456:role/sparrow
+        stsEndpoint: ""  # optional; defaults to AWS STS global endpoint
+```
+
+Static credentials remain available as a fallback for environments where
+token projection is not feasible (e.g. T-Cloud bare-metal).
+
+## Implementation
+
+The OIDC credential provider wraps `credentials.NewSTSWebIdentity` from
+minio-go. On each credential refresh, sparrow reads `tokenPath` and
+exchanges the token with STS for temporary credentials. Token rotation is
+handled entirely by the platform (kubelet, sidecar, cron) — sparrow
+re-reads the file on every STS exchange and requires no token lifecycle
+logic of its own.
+
+## Consequences
+
+- **VM deployments** require a token-refresh sidecar or cron job.
+  This is additional ops work but follows established patterns.
+- **Simpler code:** credential provider is ~30 lines — read file, call STS.
+- **Security:** token files must be mounted read-only (`0400`).
+  Kubernetes projected volumes enforce this automatically; VM operators
+  must set permissions explicitly.
+- **Extensibility:** a `tokenURL` option can be added in a future PR if
+  concrete demand emerges from teams that cannot run a sidecar. The config
+  structure reserves space for it under `auth.oidc`.
+
+## See Also
+
+- [minio-go STSWebIdentity](https://pkg.go.dev/github.com/minio/minio-go/v7/pkg/credentials#NewSTSWebIdentity)
+- [EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html)
+- [Azure Workload Identity](https://azure.github.io/azure-workload-identity/docs/)
+- [GCP Workload Identity Federation](https://cloud.google.com/iam/docs/workload-identity-federation)
+- [Kubernetes projected volumes](https://kubernetes.io/docs/concepts/storage/projected-volumes/)

--- a/pkg/sparrow/targets/remote/s3/config.go
+++ b/pkg/sparrow/targets/remote/s3/config.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/minio/minio-go/v7/pkg/credentials"
 
@@ -123,7 +125,28 @@ func (a *AuthConfig) newCredentials() (*credentials.Credentials, error) {
 			a.Static.SessionToken,
 		), nil
 	case credentialOIDC:
-		return nil, ErrOIDCNotImplemented
+		tokenFetcher := func() (*credentials.WebIdentityToken, error) {
+			data, err := os.ReadFile(a.OIDC.TokenPath)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read OIDC token from %q: %w", a.OIDC.TokenPath, err)
+			}
+			return &credentials.WebIdentityToken{
+				Token: strings.TrimSpace(string(data)),
+			}, nil
+		}
+
+		stsEndpoint := a.OIDC.STSEndpoint
+		if stsEndpoint == "" {
+			stsEndpoint = "https://sts.amazonaws.com"
+		}
+
+		return credentials.NewSTSWebIdentity(
+			stsEndpoint,
+			tokenFetcher,
+			func(s *credentials.STSWebIdentity) {
+				s.RoleARN = a.OIDC.RoleARN
+			},
+		)
 	default:
 		return nil, fmt.Errorf("%w: %q", ErrUnknownProvider, a.Provider)
 	}

--- a/pkg/sparrow/targets/remote/s3/s3.go
+++ b/pkg/sparrow/targets/remote/s3/s3.go
@@ -22,9 +22,6 @@ import (
 	"github.com/telekom/sparrow/pkg/sparrow/targets/remote"
 )
 
-// ErrOIDCNotImplemented is returned when OIDC auth is configured but not yet implemented
-var ErrOIDCNotImplemented = errors.New("OIDC authentication is not yet implemented, use static credentials")
-
 // defaultRegion is used when no region is configured
 const defaultRegion = "eu-central-1"
 

--- a/pkg/sparrow/targets/remote/s3/s3_test.go
+++ b/pkg/sparrow/targets/remote/s3/s3_test.go
@@ -11,10 +11,13 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -104,8 +107,8 @@ func TestNew_DefaultRegion(t *testing.T) {
 	assert.NotNil(t, i)
 }
 
-func TestNew_OIDCReturnsError(t *testing.T) {
-	_, err := New(&Config{
+func TestNew_OIDCAuth(t *testing.T) {
+	i, err := New(&Config{
 		Endpoint: "s3.amazonaws.com",
 		Bucket:   "test-bucket",
 		Auth: AuthConfig{
@@ -116,7 +119,8 @@ func TestNew_OIDCReturnsError(t *testing.T) {
 			},
 		},
 	})
-	require.ErrorIs(t, err, ErrOIDCNotImplemented)
+	require.NoError(t, err)
+	assert.NotNil(t, i)
 }
 
 func TestNew_UnknownProvider(t *testing.T) {
@@ -403,4 +407,44 @@ func TestConfig_Validate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestOIDC_TokenReader(t *testing.T) {
+	t.Run("reads token from file", func(t *testing.T) {
+		tokenFile := filepath.Join(t.TempDir(), "token")
+		require.NoError(t, os.WriteFile(tokenFile, []byte("  eyJhbGciOiJSUzI1NiJ9.test.sig  \n"), 0o400))
+
+		auth := AuthConfig{
+			Provider: credentialOIDC,
+			OIDC: OIDCAuthConfig{
+				TokenPath: tokenFile,
+				RoleARN:   "arn:aws:iam::123:role/test",
+			},
+		}
+
+		creds, err := auth.newCredentials()
+		require.NoError(t, err)
+		assert.NotNil(t, creds)
+	})
+
+	t.Run("error on missing file", func(t *testing.T) {
+		auth := AuthConfig{
+			Provider: credentialOIDC,
+			OIDC: OIDCAuthConfig{
+				TokenPath: "/nonexistent/path/token",
+				RoleARN:   "arn:aws:iam::123:role/test",
+			},
+		}
+
+		// newCredentials succeeds (credentials are lazy)
+		creds, err := auth.newCredentials()
+		require.NoError(t, err)
+
+		// But retrieving triggers the token read, which fails
+		_, err = creds.GetWithContext(&credentials.CredContext{
+			Client: http.DefaultClient,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to read OIDC token")
+	})
 }


### PR DESCRIPTION
## Motivation

Static credentials (access key + secret) are unsuitable for production
Kubernetes deployments where workload identity federation (WIF) is the
standard. OIDC support allows sparrow to authenticate to S3 via projected
service account tokens — compatible with AWS IRSA, Azure Workload Identity,
GCP Workload Identity, and on-prem OIDC providers.

**Stack:** PR 3/4 — builds on #434 (S3 e2e tests).

## Changes

- Wire `credentials.NewSTSWebIdentity` from minio-go with a file-based
  token reader (`tokenPath`) for STS token exchange
- Remove `ErrOIDCNotImplemented` sentinel and guard clause
- Remove `tokenURL` and `tokenHeaders` from `OIDCAuthConfig` — file-based
  token path is the universal approach (see ADR in design doc)
- Replace `ErrMissingTokenSource` with `ErrMissingTokenPath`
- Default STS endpoint to `https://sts.amazonaws.com` (configurable)
- Add token reader tests (file read, missing file error)
- Add design doc: `docs/s3-oidc-auth-design.md` (ADR with IMDS comparison
  table explaining tokenPath-only decision)

For additional information look at the commits.

## Tests done

- [x] Unit tests succeeded
- [ ] E2E tests succeeded

## TODO

- [ ] I've assigned this PR to myself
- [ ] I've labeled this PR correctly